### PR TITLE
EC2対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       #- "${CRATE_TRANSPORT_PORT}:${CRATE_TRANSPORT_PORT}"
     command: crate -Cauth.host_based.enabled=false  -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*" -Cdiscovery.type=single-node
     environment:
-      - CRATE_HEAP_SIZE=2g # see https://crate.io/docs/crate/howtos/en/latest/deployment/containers/docker.html#troubleshooting
+      - CRATE_HEAP_SIZE=1g # see https://crate.io/docs/crate/howtos/en/latest/deployment/containers/docker.html#troubleshooting
     volumes:
       - crate-db:/data
 


### PR DESCRIPTION
# 概要
インスタンスタイプ t3.small のEC2で秋田版農業情報基盤が動作するように対応する

# 修正内容

- CrateDBのヒープサイズを2GBから1GBに変更する

# 影響範囲

- データ永続化処理に影響する

# レビュー観点

- ヒープサイズが間違っていないこと

# 補足

- EC2で動作確認済み