### PR TITLE
ローカルにcontext.jsonldを配置

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - "${NGINX_PORT}:${NGINX_PORT}"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/ld:/usr/share/nginx/html/ld
     depends_on:
       - orion
       - quantumleap

--- a/init.d/strawberry-robofarm.sh
+++ b/init.d/strawberry-robofarm.sh
@@ -23,7 +23,8 @@ curl -L -X POST 'http://nginx/api/orion/ngsi-ld/v1/subscriptions/' \
     "@context": [
     "https://smart-data-models.github.io/dataModel.Device/context.jsonld",
     "https://smart-data-models.github.io/dataModel.Environment/context.jsonld",
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "http://nginx/ld/contexts/context.jsonld"
   ]
  }'
 

--- a/nginx/ld/contexts/context.jsonld
+++ b/nginx/ld/contexts/context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "type": "@type",
+    "id": "@id",
+    "speed": "https://schema.org/speed",
+    "batteryLevel": "https://smartdatamodels.org/dataModel.Device/batteryLevel"
+  }
+}


### PR DESCRIPTION
## 概要

ローカルにcontext.jsonldを配置

## 対応内容

- ローカルにcontext.jsonldを配置する
- context.jsonldには、小数で表されるspeedとbatteryLevelの定義先を記述する
- subscriptionの@contextにローカルに配置したcontext.jsonldを追加

## 影響範囲

subscription登録に影響する

## 動作確認

ローカルで動作確認し、speedとbatteryLevelが正しく取得できること。

## 制約事項

特になし

## レビュー観点

小数以下が切られてしまう現象の対策になります。
これが根本対策だ、という根拠はなく、どちらかというとカット&トライの対応になります。
(この対応を入れて様子見とさせていただきたい)

## レビュー期間

2026/02/06(Fri) - 2026/02/10(Tue)

## 補足
