### PR TITLE
サブスクリプションの多重登録抑止

### DIFF
--- a/init.d/strawberry-robofarm.sh
+++ b/init.d/strawberry-robofarm.sh
@@ -1,31 +1,81 @@
 #!/usr/bin/env sh
-set -e
+set -eu
 
-# Create subscription for AgrifarmRobotHouseSnapshot to QuantumLeap
-curl -L -X POST 'http://nginx/api/orion/ngsi-ld/v1/subscriptions/' \
--H 'Content-Type: application/ld+json' \
--H 'NGSILD-Tenant: agri_farm_robot_house' \
---data-raw '{
-  "description": "Notify me of all changes AgrifarmRobotHouseSnapshot",
-  "type": "Subscription",
-  "entities": [{"type": "AgrifarmRobotHouseSnapshot"}],
-  "watchedAttributes": ["systemTimestamp"],
-  "notification": {
-    "attributes": ["systemTimestamp", "robot", "house", "analysis"],
-    "endpoint": {
-      "uri": "http://quantumleap:8668/v2/notify",
-      "accept": "application/json",
-       "receiverInfo": [
-                    { "key": "Fiware-TimeIndex-Attribute", "value": "systemTimestamp" }
-       ]
-    }
-  },
-    "@context": [
-    "https://smart-data-models.github.io/dataModel.Device/context.jsonld",
-    "https://smart-data-models.github.io/dataModel.Environment/context.jsonld",
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
-    "http://nginx/ld/contexts/context.jsonld"
-  ]
- }'
+#############################################
+# 設定（環境変数で上書き可能）
+#############################################
+BROKER_BASE_URL="${BROKER_BASE_URL:-http://nginx/api/orion/ngsi-ld/v1}"
+TENANT="${TENANT:-agri_farm_robot_house}"
+SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-urn:ngsi-ld:Subscription:AgrifarmRobotHouseSnapshotToQL}"
+NOTIFY_URI="${NOTIFY_URI:-http://quantumleap:8668/v2/notify}"
 
-echo "Subscription for AgrifarmRobotHouseSnapshot created."
+# 共通ヘッダ
+COMMON_HEADERS="-H Content-Type:application/ld+json -H NGSILD-Tenant:${TENANT}"
+
+#############################################
+# 起動待ち（ブローカー疎通確認）
+#############################################
+echo "Waiting for Orion-LD at ${BROKER_BASE_URL} ..."
+for i in $(seq 1 60); do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "${BROKER_BASE_URL}/subscriptions/")
+  if [ "$code" != "000" ] && [ "$code" -ne 502 ] && [ "$code" -ne 503 ] && [ "$code" -ne 504 ]; then
+    echo "Orion-LD is reachable (HTTP $code)."
+    break
+  fi
+  sleep 2
+done
+
+#############################################
+# 1) 既存確認（GET /subscriptions/{id}）
+#############################################
+echo "Checking if subscription exists: ${SUBSCRIPTION_ID}"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "NGSILD-Tenant: ${TENANT}" \
+  "${BROKER_BASE_URL}/subscriptions/${SUBSCRIPTION_ID}")
+
+#############################################
+# 2) 新規作成（無ければPOST）
+#############################################
+if [ "$STATUS" -eq 404 ]; then
+  echo "Not found. Creating subscription ${SUBSCRIPTION_ID} ..."
+  curl -sS -L -X POST "${BROKER_BASE_URL}/subscriptions/" \
+    $COMMON_HEADERS \
+    --data-raw "{
+      \"id\": \"${SUBSCRIPTION_ID}\",
+      \"description\": \"Notify me of all changes AgrifarmRobotHouseSnapshot\",
+      \"type\": \"Subscription\",
+      \"entities\": [{\"type\": \"AgrifarmRobotHouseSnapshot\"}],
+      \"watchedAttributes\": [\"systemTimestamp\"],
+      \"notification\": {
+        \"attributes\": [\"systemTimestamp\", \"robot\", \"house\", \"analysis\"],
+        \"endpoint\": {
+          \"uri\": \"${NOTIFY_URI}\",
+          \"accept\": \"application/json\",
+          \"receiverInfo\": [
+            { \"key\": \"Fiware-TimeIndex-Attribute\", \"value\": \"systemTimestamp\" }
+          ]
+        }
+      },
+      \"@context\": [
+        \"https://smart-data-models.github.io/dataModel.Device/context.jsonld\",
+        \"https://smart-data-models.github.io/dataModel.Environment/context.jsonld\",
+        \"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld\",
+        \"http://nginx/ld/contexts/context.jsonld\"
+      ]
+    }"
+  echo
+  echo "Subscription created."
+#############################################
+# 3) 既存
+#############################################
+elif [ "$STATUS" -eq 200 ]; then
+  echo "Already exists."
+#############################################
+# 4) 想定外のステータス
+#############################################
+else
+  echo "Unexpected response when checking subscription: HTTP $STATUS" >&2
+  exit 1
+fi
+
+echo "Done."


### PR DESCRIPTION
## 概要

サブスクリプションの多重登録抑止

## 対応内容

platform初期化処理で既にサブスクリプション登録を行っているかチェックして、登録されていない場合のみサブスクリプション登録を行うように修正。

## 影響範囲

- platform初期化処理
- 時系列データの登録処理

## 動作確認

ローカル環境で以下の動作を確認した。
- サブスクリプション登録を行われていない状態でplatformを起動すると初期化処理でサブスクリプション登録が行われること。
- 既にサブスクリプション登録を行っている状態でplatformを起動すると初期化処理でサブスクリプション登録が行われないこと。

## 制約事項

## レビュー観点

## レビュー期間

2026/02/12(Thu) - 2026/02/17(Tue)

## 補足
