### PR TITLE
第三者評価ダッシュボード作成

### DIFF
--- a/grafana/dashboards/3rdPartyEvaluation.json
+++ b/grafana/dashboards/3rdPartyEvaluation.json
@@ -22,17 +22,1041 @@
   "links": [],
   "panels": [
     {
-      "collapsed": false,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 10,
-      "panels": [],
+      "id": 142,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>評価軸</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "P0DB2B379060E8607"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "収穫精度",
+              "url": "#section-harvest-accuracy"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 0,
+        "y": 2
+      },
+      "id": 130,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^haStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "columns": [],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "(\n  /* タイムスタンプ */\n  $ts := $.attributes[attrName = \"systemTimestamp\"].values;\n\n  /* adaptability (ad) */\n  $adAction := $.attributes[attrName = \"analysis\"].values.adaptability.action;\n  $adDataCo2 := $.attributes[attrName = \"analysis\"].values.adaptability.data.co2;\n  $adDataHumidity := $.attributes[attrName = \"analysis\"].values.adaptability.data.humidity;\n  $adDataIlluminance := $.attributes[attrName = \"analysis\"].values.adaptability.data.illuminance;\n  $adDataPitch := $.attributes[attrName = \"analysis\"].values.adaptability.data.pitch;\n  $adDataRoll := $.attributes[attrName = \"analysis\"].values.adaptability.data.roll;\n  $adDataTemperature := $.attributes[attrName = \"analysis\"].values.adaptability.data.temperature;\n  $adDataYaw := $.attributes[attrName = \"analysis\"].values.adaptability.data.yaw;\n  $adDiagnosis := $.attributes[attrName = \"analysis\"].values.adaptability.diagnosis;\n  $adStatus := $.attributes[attrName = \"analysis\"].values.adaptability.status;\n\n  /* costEfficiency (ce) */\n  $ceAction := $.attributes[attrName = \"analysis\"].values.costEfficiency.action;\n  $ceDataHarvestCount := $.attributes[attrName = \"analysis\"].values.costEfficiency.data.harvestCount;\n  $ceDataOperatingTime := $.attributes[attrName = \"analysis\"].values.costEfficiency.data.operatingTime;\n  $ceDataTotalStopTime := $.attributes[attrName = \"analysis\"].values.costEfficiency.data.totalStopTime;\n  $ceDiagnosis := $.attributes[attrName = \"analysis\"].values.costEfficiency.diagnosis;\n  $ceStatus := $.attributes[attrName = \"analysis\"].values.costEfficiency.status;\n\n  /* dataUtilization (du) */\n  $duAction := $.attributes[attrName = \"analysis\"].values.dataUtilization.action;\n  $duDiagnosis := $.attributes[attrName = \"analysis\"].values.dataUtilization.diagnosis;\n  $duStatus := $.attributes[attrName = \"analysis\"].values.dataUtilization.status;\n\n  /* durability (db) */\n  $dbAction := $.attributes[attrName = \"analysis\"].values.durability.action;\n  $dbDataFailureCount := $.attributes[attrName = \"analysis\"].values.durability.data.failureCount;\n  $dbDataOperatingTime := $.attributes[attrName = \"analysis\"].values.durability.data.operatingTime;\n  $dbDataProcessingTime := $.attributes[attrName = \"analysis\"].values.durability.data.processingTime;\n  $dbDataRobotSpeed := $.attributes[attrName = \"analysis\"].values.durability.data.robotSpeed;\n  $dbDataStatusCode := $.attributes[attrName = \"analysis\"].values.durability.data.statusCode;\n  $dbDataTotalStopTime := $.attributes[attrName = \"analysis\"].values.durability.data.totalStopTime;\n  $dbDiagnosis := $.attributes[attrName = \"analysis\"].values.durability.diagnosis;\n  $dbMetricsMtbf := $.attributes[attrName = \"analysis\"].values.durability.metrics.mtbf;\n  $dbMetricsOperationRate := $.attributes[attrName = \"analysis\"].values.durability.metrics.operationRate;\n  $dbStatus := $.attributes[attrName = \"analysis\"].values.durability.status;\n\n  /* ethics (et) */\n  $etAction := $.attributes[attrName = \"analysis\"].values.ethics.action;\n  $etDiagnosis := $.attributes[attrName = \"analysis\"].values.ethics.diagnosis;\n  $etStatus := $.attributes[attrName = \"analysis\"].values.ethics.status;\n\n  /* harvestAccuracy (ha) */\n  $haAction := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.action;\n  $haDataDetectionCount := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.data.detectionCount;\n  $haDataHarvestCount := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.data.harvestCount;\n  $haDiagnosis := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.diagnosis;\n  $haMetricsAmbiguityRate := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.metrics.ambiguityRate;\n  $haMetricsUncertainCount := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.metrics.uncertainCount;\n  $haStatus := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.status;\n\n  /* harvestSpeed (hs) */\n  $hsAction := $.attributes[attrName = \"analysis\"].values.harvestSpeed.action;\n  $hsDataOperatingTime := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.operatingTime;\n  $hsDataProcessingTime := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.processingTime;\n  $hsDataRobotSpeed := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.robotSpeed;\n  $hsDataStatusCode := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.statusCode;\n  $hsDataTravelStopTime := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.travelStopTime;\n  $hsDiagnosis := $.attributes[attrName = \"analysis\"].values.harvestSpeed.diagnosis;\n  $hsMetricsStopRate := $.attributes[attrName = \"analysis\"].values.harvestSpeed.metrics.stopRate;\n  $hsStatus := $.attributes[attrName = \"analysis\"].values.harvestSpeed.status;\n\n  /* maintainability (mn) */\n  $mnAction := $.attributes[attrName = \"analysis\"].values.maintainability.action;\n  $mnDataFailureCount := $.attributes[attrName = \"analysis\"].values.maintainability.data.failureCount;\n  $mnDataPartFailureProbsArm := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.arm;\n  $mnDataPartFailureProbsCamera := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.camera;\n  $mnDataPartFailureProbsCommunication := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.communication;\n  $mnDataPartFailureProbsControlUnit := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.controlUnit;\n  $mnDataPartFailureProbsHand := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.hand;\n  $mnDataPartFailureProbsPower := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.power;\n  $mnDataPartFailureProbsTray := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.tray;\n  $mnDataPartFailureProbsWheels := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.wheels;\n  $mnDataTotalStopTime := $.attributes[attrName = \"analysis\"].values.maintainability.data.totalStopTime;\n  $mnDiagnosis := $.attributes[attrName = \"analysis\"].values.maintainability.diagnosis;\n  $mnMetricsMttr := $.attributes[attrName = \"analysis\"].values.maintainability.metrics.mttr;\n  $mnStatus := $.attributes[attrName = \"analysis\"].values.maintainability.status;\n\n  /* operability (op) */\n  $opAction := $.attributes[attrName = \"analysis\"].values.operability.action;\n  $opDataOperationErrors := $.attributes[attrName = \"analysis\"].values.operability.data.operationErrors;\n  $opDataOperationSteps := $.attributes[attrName = \"analysis\"].values.operability.data.operationSteps;\n  $opDataOperationTime := $.attributes[attrName = \"analysis\"].values.operability.data.operationTime;\n  $opDiagnosis := $.attributes[attrName = \"analysis\"].values.operability.diagnosis;\n  $opMetricsOperationErrorRate := $.attributes[attrName = \"analysis\"].values.operability.metrics.operationErrorRate;\n  $opStatus := $.attributes[attrName = \"analysis\"].values.operability.status;\n\n  /* safety (sa) */\n  $saAction := $.attributes[attrName = \"analysis\"].values.safety.action;\n  $saDataRiskDetectionCount := $.attributes[attrName = \"analysis\"].values.safety.data.riskDetectionCount;\n  $saDataSafetyActivationCount := $.attributes[attrName = \"analysis\"].values.safety.data.safetyActivationCount;\n  $saDiagnosis := $.attributes[attrName = \"analysis\"].values.safety.diagnosis;\n  $saStatus := $.attributes[attrName = \"analysis\"].values.safety.status;\n\n  /* 出力 */\n  $map($ts, function($v, $i) {\n    {\n      \"timestamp\": $v,\n\n      /* ad */\n      \"adAction\": $adAction[$i],\n      \"adDataCo2\": $adDataCo2[$i],\n      \"adDataHumidity\": $adDataHumidity[$i],\n      \"adDataIlluminance\": $adDataIlluminance[$i],\n      \"adDataPitch\": $adDataPitch[$i],\n      \"adDataRoll\": $adDataRoll[$i],\n      \"adDataTemperature\": $adDataTemperature[$i],\n      \"adDataYaw\": $adDataYaw[$i],\n      \"adDiagnosis\": $adDiagnosis[$i],\n      \"adStatus\": $adStatus[$i],\n\n      /* ce */\n      \"ceAction\": $ceAction[$i],\n      \"ceDataHarvestCount\": $ceDataHarvestCount[$i],\n      \"ceDataOperatingTime\": $ceDataOperatingTime[$i],\n      \"ceDataTotalStopTime\": $ceDataTotalStopTime[$i],\n      \"ceDiagnosis\": $ceDiagnosis[$i],\n      \"ceStatus\": $ceStatus[$i],\n\n      /* du */\n      \"duAction\": $duAction[$i],\n      \"duDiagnosis\": $duDiagnosis[$i],\n      \"duStatus\": $duStatus[$i],\n\n      /* db */\n      \"dbAction\": $dbAction[$i],\n      \"dbDataFailureCount\": $dbDataFailureCount[$i],\n      \"dbDataOperatingTime\": $dbDataOperatingTime[$i],\n      \"dbDataProcessingTime\": $dbDataProcessingTime[$i],\n      \"dbDataRobotSpeed\": $dbDataRobotSpeed[$i],\n      \"dbDataStatusCode\": $dbDataStatusCode[$i],\n      \"dbDataTotalStopTime\": $dbDataTotalStopTime[$i],\n      \"dbDiagnosis\": $dbDiagnosis[$i],\n      \"dbMetricsMtbf\": $dbMetricsMtbf[$i],\n      \"dbMetricsOperationRate\": $dbMetricsOperationRate[$i],\n      \"dbStatus\": $dbStatus[$i],\n\n      /* et */\n      \"etAction\": $etAction[$i],\n      \"etDiagnosis\": $etDiagnosis[$i],\n      \"etStatus\": $etStatus[$i],\n\n      /* ha */\n      \"haAction\": $haAction[$i],\n      \"haDataDetectionCount\": $haDataDetectionCount[$i],\n      \"haDataHarvestCount\": $haDataHarvestCount[$i],\n      \"haDiagnosis\": $haDiagnosis[$i],\n      \"haMetricsAmbiguityRate\": $haMetricsAmbiguityRate[$i],\n      \"haMetricsUncertainCount\": $haMetricsUncertainCount[$i],\n      \"haStatus\": $haStatus[$i],\n\n      /* hs */\n      \"hsAction\": $hsAction[$i],\n      \"hsDataOperatingTime\": $hsDataOperatingTime[$i],\n      \"hsDataProcessingTime\": $hsDataProcessingTime[$i],\n      \"hsDataRobotSpeed\": $hsDataRobotSpeed[$i],\n      \"hsDataStatusCode\": $hsDataStatusCode[$i],\n      \"hsDataTravelStopTime\": $hsDataTravelStopTime[$i],\n      \"hsDiagnosis\": $hsDiagnosis[$i],\n      \"hsMetricsStopRate\": $hsMetricsStopRate[$i],\n      \"hsStatus\": $hsStatus[$i],\n\n      /* mn */\n      \"mnAction\": $mnAction[$i],\n      \"mnDataFailureCount\": $mnDataFailureCount[$i],\n      \"mnDataPartFailureProbsArm\": $mnDataPartFailureProbsArm[$i],\n      \"mnDataPartFailureProbsCamera\": $mnDataPartFailureProbsCamera[$i],\n      \"mnDataPartFailureProbsCommunication\": $mnDataPartFailureProbsCommunication[$i],\n      \"mnDataPartFailureProbsControlUnit\": $mnDataPartFailureProbsControlUnit[$i],\n      \"mnDataPartFailureProbsHand\": $mnDataPartFailureProbsHand[$i],\n      \"mnDataPartFailureProbsPower\": $mnDataPartFailureProbsPower[$i],\n      \"mnDataPartFailureProbsTray\": $mnDataPartFailureProbsTray[$i],\n      \"mnDataPartFailureProbsWheels\": $mnDataPartFailureProbsWheels[$i],\n      \"mnDataTotalStopTime\": $mnDataTotalStopTime[$i],\n      \"mnDiagnosis\": $mnDiagnosis[$i],\n      \"mnMetricsMttr\": $mnMetricsMttr[$i],\n      \"mnStatus\": $mnStatus[$i],\n\n      /* op */\n      \"opAction\": $opAction[$i],\n      \"opDataOperationErrors\": $opDataOperationErrors[$i],\n      \"opDataOperationSteps\": $opDataOperationSteps[$i],\n      \"opDataOperationTime\": $opDataOperationTime[$i],\n      \"opDiagnosis\": $opDiagnosis[$i],\n      \"opMetricsOperationErrorRate\": $opMetricsOperationErrorRate[$i],\n      \"opStatus\": $opStatus[$i],\n\n      /* sa */\n      \"saAction\": $saAction[$i],\n      \"saDataRiskDetectionCount\": $saDataRiskDetectionCount[$i],\n      \"saDataSafetyActivationCount\": $saDataSafetyActivationCount[$i],\n      \"saDiagnosis\": $saDiagnosis[$i],\n      \"saStatus\": $saStatus[$i]\n    }\n  })\n)",
+          "source": "url",
+          "type": "json",
+          "url": "/v2/entities/urn:ngsi-ld:AgrifarmRobotHouseSnapshot:site-01/value",
+          "url_options": {
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Fiware-Service",
+                "value": "agri_farm_robot_house"
+              },
+              {
+                "key": "Fiware-ServicePath",
+                "value": "/"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "fromDate",
+                "value": "${__from:date:iso}"
+              },
+              {
+                "key": "toDate",
+                "value": "${__to:date:iso}"
+              }
+            ]
+          }
+        }
+      ],
       "title": "収穫精度",
-      "type": "row"
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "収穫速度",
+              "url": "#section-harvest-speed"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 2,
+        "y": 2
+      },
+      "id": 131,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^hsStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "収穫速度",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "環境適応性",
+              "url": "#section-adaptability"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 4,
+        "y": 2
+      },
+      "id": 132,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^adStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "環境適応性",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "操作性",
+              "url": "#section-operability"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 6,
+        "y": 2
+      },
+      "id": 133,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "操作性",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "メンテナンス性",
+              "url": "#section-maintainability"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 8,
+        "y": 2
+      },
+      "id": 134,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "メンテナンス性",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "コスト効率",
+              "url": "#section-cost-efficiency"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 10,
+        "y": 2
+      },
+      "id": 135,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^ceStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "コスト効率",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "安全性",
+              "url": "#section-safety"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 12,
+        "y": 2
+      },
+      "id": 136,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^saStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "安全性",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "データ活用",
+              "url": "#section-data-utilization"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 14,
+        "y": 2
+      },
+      "id": 137,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^duStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "データ活用",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "耐久性",
+              "url": "#section-durability"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 16,
+        "y": 2
+      },
+      "id": 138,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "耐久性",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "title": "倫理性",
+              "url": "#section-ethics"
+            }
+          ],
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 18,
+        "y": 2
+      },
+      "id": 139,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^etStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "倫理性",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 140,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<div id=\"section-harvest-accuracy\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 141,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>収穫精度</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -87,7 +1111,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 1
+        "y": 10
       },
       "id": 11,
       "options": {
@@ -217,9 +1241,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 1
+        "y": 10
       },
       "id": 12,
       "options": {
@@ -306,9 +1330,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 5
+        "y": 14
       },
       "id": 14,
       "options": {
@@ -367,9 +1391,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 5
+        "w": 12,
+        "x": 12,
+        "y": 14
       },
       "id": 15,
       "options": {
@@ -404,33 +1428,6 @@
       "type": "stat"
     },
     {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 22,
-        "x": 0,
-        "y": 7
-      },
-      "id": 55,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "12.0.2",
-      "title": "メトリクス",
-      "transparent": true,
-      "type": "text"
-    },
-    {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
@@ -441,67 +1438,13 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "個"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 8
-      },
-      "id": 52,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^haMetricsUncertainCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "不確実判定数",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
           },
           "mappings": [],
           "thresholds": {
@@ -514,31 +1457,39 @@
           },
           "unit": "percent"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "不確実判定数"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "個"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 8
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 16
       },
-      "id": 53,
+      "id": 122,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^haMetricsAmbiguityRate$/",
-          "values": false
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -551,8 +1502,460 @@
           "refId": "A"
         }
       ],
-      "title": "曖昧判定率",
-      "type": "stat"
+      "title": "メトリクス",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": false,
+              "haMetricsUncertainCount": false,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 5,
+              "adDataRoll": 6,
+              "adDataTemperature": 7,
+              "adDataYaw": 4,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 38,
+              "haMetricsUncertainCount": 37,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "adDataPitch": "ピッチ",
+              "adDataRoll": "ロール",
+              "adDataYaw": "ヨー",
+              "haMetricsAmbiguityRate": "曖昧判定率",
+              "haMetricsUncertainCount": "不確実判定数",
+              "hsMetricsStopRate": "走行停止率",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "個"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 121,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "データ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": false,
+              "haDataHarvestCount": false,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 5,
+              "adDataRoll": 6,
+              "adDataTemperature": 7,
+              "adDataYaw": 4,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 35,
+              "haDataHarvestCount": 34,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 43,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 41,
+              "hsDataStatusCode": 45,
+              "hsDataTravelStopTime": 44,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "adDataPitch": "ピッチ",
+              "adDataRoll": "ロール",
+              "adDataYaw": "ヨー",
+              "etStatus": "",
+              "haDataDetectionCount": "検知数",
+              "haDataHarvestCount": "収穫数",
+              "hsDataOperatingTime": "収穫稼働時間",
+              "hsDataProcessingTime": "1果実あたりの処理時間",
+              "hsDataRobotSpeed": "ロボット走行速度",
+              "hsDataStatusCode": "ロボットステータス",
+              "hsDataTravelStopTime": "走行停止時間",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "description": "",
@@ -561,162 +1964,52 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 1,
-        "w": 22,
+        "h": 2,
+        "w": 24,
         "x": 0,
-        "y": 11
+        "y": 24
       },
-      "id": 102,
+      "id": 144,
       "options": {
         "code": {
           "language": "plaintext",
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "",
-        "mode": "markdown"
+        "content": "<div id=\"section-harvest-speed\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
       },
       "pluginVersion": "12.0.2",
-      "title": "データ",
+      "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
+      "description": "",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "個"
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 12
-      },
-      "id": 54,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^haDataHarvestCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "収穫数",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "個"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 12
-      },
-      "id": 103,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^haDataDetectionCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "検知数",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 26
       },
-      "id": 9,
-      "panels": [],
-      "title": "収穫速度",
-      "type": "row"
+      "id": 143,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>収穫速度</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -770,7 +2063,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 16
+        "y": 28
       },
       "id": 16,
       "options": {
@@ -827,7 +2120,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "収穫速度",
           "mappings": [
             {
               "options": {
@@ -868,9 +2161,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 16
+        "y": 28
       },
       "id": 19,
       "options": {
@@ -900,7 +2193,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -957,9 +2250,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 20
+        "y": 32
       },
       "id": 18,
       "options": {
@@ -1018,9 +2311,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 20
+        "w": 12,
+        "x": 12,
+        "y": 32
       },
       "id": 17,
       "options": {
@@ -1055,33 +2348,6 @@
       "type": "stat"
     },
     {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 22,
-        "x": 0,
-        "y": 22
-      },
-      "id": 105,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "12.0.2",
-      "title": "メトリクス",
-      "transparent": true,
-      "type": "text"
-    },
-    {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
@@ -1091,6 +2357,14 @@
         "defaults": {
           "color": {
             "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
           },
           "mappings": [],
           "thresholds": {
@@ -1107,31 +2381,41 @@
           },
           "unit": "percent"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ヨー"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
+        "h": 4,
+        "w": 24,
         "x": 0,
-        "y": 23
+        "y": 34
       },
-      "id": 56,
+      "id": 120,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^hsMetricsStopRate$/",
-          "values": false
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -1144,8 +2428,538 @@
           "refId": "A"
         }
       ],
-      "title": "走行停止率",
-      "type": "stat"
+      "title": "メトリクス",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": false,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 5,
+              "adDataRoll": 6,
+              "adDataTemperature": 7,
+              "adDataYaw": 4,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "adDataPitch": "ピッチ",
+              "adDataRoll": "ロール",
+              "adDataYaw": "ヨー",
+              "hsMetricsStopRate": "走行停止率",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ロボットステータス"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "E-01": {
+                        "index": 9,
+                        "text": "バッテリー残量低下"
+                      },
+                      "H-01": {
+                        "index": 7,
+                        "text": "視界不良"
+                      },
+                      "H-02": {
+                        "index": 8,
+                        "text": "収穫物満タン"
+                      },
+                      "R-01": {
+                        "index": 4,
+                        "text": "足元スタック"
+                      },
+                      "R-02": {
+                        "index": 5,
+                        "text": "進路妨害"
+                      },
+                      "R-03": {
+                        "index": 6,
+                        "text": "脱輪・転倒"
+                      },
+                      "S-01": {
+                        "index": 0,
+                        "text": "待機中"
+                      },
+                      "S-02": {
+                        "index": 1,
+                        "text": "移動中"
+                      },
+                      "S-03": {
+                        "index": 2,
+                        "text": "収穫中"
+                      },
+                      "S-04": {
+                        "index": 3,
+                        "text": "帰還中"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ロボット走行速度"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "velocityms"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1果実あたりの処理時間"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "秒"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 119,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "データ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": false,
+              "hsDataProcessingTime": false,
+              "hsDataRobotSpeed": false,
+              "hsDataStatusCode": false,
+              "hsDataTravelStopTime": false,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 5,
+              "adDataRoll": 6,
+              "adDataTemperature": 7,
+              "adDataYaw": 4,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 43,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 41,
+              "hsDataStatusCode": 45,
+              "hsDataTravelStopTime": 44,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "adDataPitch": "ピッチ",
+              "adDataRoll": "ロール",
+              "adDataYaw": "ヨー",
+              "hsDataOperatingTime": "収穫稼働時間",
+              "hsDataProcessingTime": "1果実あたりの処理時間",
+              "hsDataRobotSpeed": "ロボット走行速度",
+              "hsDataStatusCode": "ロボットステータス",
+              "hsDataTravelStopTime": "走行停止時間",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "description": "",
@@ -1154,393 +2968,52 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 1,
-        "w": 22,
+        "h": 2,
+        "w": 24,
         "x": 0,
-        "y": 26
+        "y": 42
       },
-      "id": 104,
+      "id": 145,
       "options": {
         "code": {
           "language": "plaintext",
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "",
-        "mode": "markdown"
+        "content": "<div id=\"section-adaptability\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
       },
       "pluginVersion": "12.0.2",
-      "title": "データ",
+      "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "velocityms"
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 27
-      },
-      "id": 57,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^hsDataRobotSpeed$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "ロボット走行速度",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "秒"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 27
-      },
-      "id": 58,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^hsDataProcessingTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "1果実あたりの処理時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "分"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 27
-      },
-      "id": 59,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^hsDataOperatingTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "収穫稼働時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "分"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 27
-      },
-      "id": 60,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^hsDataTravelStopTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "走行停止時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [
-            {
-              "options": {
-                "E-01": {
-                  "index": 9,
-                  "text": "バッテリー残量低下"
-                },
-                "H-01": {
-                  "index": 7,
-                  "text": "視界不良"
-                },
-                "H-02": {
-                  "index": 8,
-                  "text": "収穫物満タン"
-                },
-                "R-01": {
-                  "index": 4,
-                  "text": "足元スタック"
-                },
-                "R-02": {
-                  "index": 5,
-                  "text": "進路妨害"
-                },
-                "R-03": {
-                  "index": 6,
-                  "text": "脱輪・転倒"
-                },
-                "S-01": {
-                  "index": 0,
-                  "text": "待機中"
-                },
-                "S-02": {
-                  "index": 1,
-                  "text": "移動中"
-                },
-                "S-03": {
-                  "index": 2,
-                  "text": "収穫中"
-                },
-                "S-04": {
-                  "index": 3,
-                  "text": "帰還中"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 27
-      },
-      "id": 62,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^hsDataStatusCode$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "ロボットステータス",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 44
       },
-      "id": 8,
-      "panels": [],
-      "title": "環境適応性",
-      "type": "row"
+      "id": 146,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>環境適応性</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -1594,7 +3067,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 31
+        "y": 46
       },
       "id": 20,
       "options": {
@@ -1651,7 +3124,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "環境適応性",
           "mappings": [
             {
               "options": {
@@ -1692,9 +3165,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 31
+        "y": 46
       },
       "id": 28,
       "options": {
@@ -1724,7 +3197,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -1781,9 +3254,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 35
+        "y": 50
       },
       "id": 36,
       "options": {
@@ -1842,9 +3315,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 35
+        "w": 12,
+        "x": 12,
+        "y": 50
       },
       "id": 37,
       "options": {
@@ -1879,233 +3352,280 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
       "description": "",
       "fieldConfig": {
-        "defaults": {},
-        "overrides": []
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": -5
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ヨー"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 1,
-        "w": 22,
+        "h": 4,
+        "w": 24,
         "x": 0,
-        "y": 37
+        "y": 52
       },
-      "id": 107,
+      "id": 116,
       "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "content": "",
-        "mode": "markdown"
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
       "title": "データ",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "degree"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 38
-      },
-      "id": 63,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^adDataYaw$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
+      "transformations": [
         {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": false,
+              "adDataRoll": false,
+              "adDataTemperature": true,
+              "adDataYaw": false,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 5,
+              "adDataRoll": 6,
+              "adDataTemperature": 7,
+              "adDataYaw": 4,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "adDataPitch": "ピッチ",
+              "adDataRoll": "ロール",
+              "adDataYaw": "ヨー",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
         }
       ],
-      "title": "ヨー",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red"
-              },
-              {
-                "color": "green",
-                "value": -5
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "degree"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 38
-      },
-      "id": 64,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^adDataPitch$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "ピッチ",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red"
-              },
-              {
-                "color": "green",
-                "value": -5
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "degree"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 38
-      },
-      "id": 65,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^adDataRoll$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "ロール",
-      "type": "stat"
+      "type": "table"
     },
     {
       "datasource": {
@@ -2151,7 +3671,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 41
+        "y": 56
       },
       "id": 66,
       "options": {
@@ -2259,9 +3779,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 41
+        "y": 56
       },
       "id": 67,
       "options": {
@@ -2364,7 +3884,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 46
+        "y": 61
       },
       "id": 68,
       "options": {
@@ -2473,9 +3993,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 46
+        "y": 61
       },
       "id": 69,
       "options": {
@@ -2578,7 +4098,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 51
+        "y": 66
       },
       "id": 70,
       "options": {
@@ -2687,9 +4207,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 51
+        "y": 66
       },
       "id": 71,
       "options": {
@@ -2792,7 +4312,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 56
+        "y": 71
       },
       "id": 72,
       "options": {
@@ -2901,9 +4421,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 56
+        "y": 71
       },
       "id": 73,
       "options": {
@@ -2963,17 +4483,58 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 76
       },
-      "id": 7,
-      "panels": [],
-      "title": "操作性",
-      "type": "row"
+      "id": 148,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<div id=\"section-operability\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 147,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>操作性</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -3027,7 +4588,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 62
+        "y": 80
       },
       "id": 21,
       "options": {
@@ -3084,7 +4645,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "操作性",
           "mappings": [
             {
               "options": {
@@ -3125,9 +4686,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 62
+        "y": 80
       },
       "id": 29,
       "options": {
@@ -3157,7 +4718,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -3214,9 +4775,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 66
+        "y": 84
       },
       "id": 38,
       "options": {
@@ -3275,9 +4836,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 66
+        "w": 12,
+        "x": 12,
+        "y": 84
       },
       "id": 39,
       "options": {
@@ -3312,33 +4873,6 @@
       "type": "stat"
     },
     {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 22,
-        "x": 0,
-        "y": 68
-      },
-      "id": 106,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "12.0.2",
-      "title": "メトリクス",
-      "transparent": true,
-      "type": "text"
-    },
-    {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
@@ -3348,6 +4882,14 @@
         "defaults": {
           "color": {
             "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
           },
           "mappings": [],
           "thresholds": {
@@ -3367,28 +4909,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
+        "h": 4,
+        "w": 24,
         "x": 0,
-        "y": 69
+        "y": 86
       },
-      "id": 74,
+      "id": 123,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^opMetricsOperationErrorRate$/",
-          "values": false
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -3401,167 +4938,195 @@
           "refId": "A"
         }
       ],
-      "title": "操作エラー率",
-      "type": "stat"
-    },
-    {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 22,
-        "x": 0,
-        "y": 72
-      },
-      "id": 108,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
+      "title": "メトリクス",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": false,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnMetricsMttr": "MTTR",
+              "opDataOperationSteps": "",
+              "opMetricsOperationErrorRate": "操作エラー率"
+            }
+          }
         },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "12.0.2",
-      "title": "データ",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 30
-              }
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
             ]
-          },
-          "unit": "分"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 73
-      },
-      "id": 75,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^opDataOperationTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
+          }
         }
       ],
-      "title": "操作時間（平均）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "回"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 73
-      },
-      "id": 76,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^opDataOperationSteps$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "操作ステップ数（平均）",
-      "type": "stat"
+      "type": "table"
     },
     {
       "datasource": {
@@ -3574,6 +5139,14 @@
           "color": {
             "mode": "fixed"
           },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -3585,31 +5158,83 @@
           },
           "unit": "回"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "操作時間（平均）"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "分"
+              },
+              {
+                "id": "color"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 30
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "操作ステップ数（平均）"
+            },
+            "properties": [
+              {
+                "id": "color"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 73
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 90
       },
-      "id": 77,
+      "id": 124,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^opDataOperationErrors$/",
-          "values": false
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -3622,21 +5247,251 @@
           "refId": "A"
         }
       ],
-      "title": "操作エラー数（平均）",
-      "type": "stat"
+      "title": "データ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": false,
+              "opDataOperationSteps": false,
+              "opDataOperationTime": false,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 66,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 64,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "mnDataFailureCount": "故障回数",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnDataTotalStopTime": "停止時間",
+              "opDataOperationErrors": "操作エラー数（平均）",
+              "opDataOperationSteps": "操作ステップ数（平均）",
+              "opDataOperationTime": "操作時間（平均）"
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
     },
     {
-      "collapsed": false,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 94
       },
-      "id": 6,
-      "panels": [],
-      "title": "メンテナンス性",
-      "type": "row"
+      "id": 150,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<div id=\"section-maintainability\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 96
+      },
+      "id": 149,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>メンテナンス性</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -3690,7 +5545,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 77
+        "y": 98
       },
       "id": 22,
       "options": {
@@ -3747,7 +5602,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "メンテナンス性",
           "mappings": [
             {
               "options": {
@@ -3788,9 +5643,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 77
+        "y": 98
       },
       "id": 30,
       "options": {
@@ -3820,7 +5675,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -3877,9 +5732,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 81
+        "y": 102
       },
       "id": 40,
       "options": {
@@ -3938,9 +5793,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 81
+        "w": 12,
+        "x": 12,
+        "y": 102
       },
       "id": 41,
       "options": {
@@ -3975,33 +5830,6 @@
       "type": "stat"
     },
     {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 22,
-        "x": 0,
-        "y": 83
-      },
-      "id": 109,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "12.0.2",
-      "title": "メトリクス",
-      "transparent": true,
-      "type": "text"
-    },
-    {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
@@ -4011,6 +5839,14 @@
         "defaults": {
           "color": {
             "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
           },
           "mappings": [],
           "thresholds": {
@@ -4025,33 +5861,28 @@
               }
             ]
           },
-          "unit": "時間"
+          "unit": "percent"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
+        "h": 4,
+        "w": 24,
         "x": 0,
-        "y": 84
+        "y": 104
       },
-      "id": 78,
+      "id": 117,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^mnMetricsMttr$/",
-          "values": false
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -4064,35 +5895,194 @@
           "refId": "A"
         }
       ],
-      "title": "MTTR",
-      "type": "stat"
-    },
-    {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 22,
-        "x": 0,
-        "y": 87
-      },
-      "id": 110,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
+      "title": "メトリクス",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": false,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnMetricsMttr": "MTTR",
+              "opDataOperationSteps": ""
+            }
+          }
         },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "12.0.2",
-      "title": "データ",
-      "transparent": true,
-      "type": "text"
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": {
@@ -4104,137 +6094,14 @@
         "defaults": {
           "color": {
             "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "回"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 88
-      },
-      "id": 84,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataFailureCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "故障回数",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "分"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 88
-      },
-      "id": 83,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataTotalStopTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "停止時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "color-text"
             },
-            "inspect": false
+            "inspect": false,
+            "width": 170
           },
           "mappings": [],
           "thresholds": {
@@ -4255,11 +6122,267 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 22,
+        "w": 24,
         "x": 0,
-        "y": 91
+        "y": 108
       },
       "id": 115,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "データ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": false,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": false,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "mnDataFailureCount": "故障回数",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnDataTotalStopTime": "停止時間",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 112
+      },
+      "id": 118,
       "options": {
         "cellHeight": "sm",
         "footer": {
@@ -4464,17 +6587,58 @@
       "type": "table"
     },
     {
-      "collapsed": false,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 95
+        "y": 116
       },
-      "id": 5,
-      "panels": [],
-      "title": "コスト効率",
-      "type": "row"
+      "id": 154,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<div id=\"section-cost-efficiency\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 118
+      },
+      "id": 151,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>コスト効率</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -4529,7 +6693,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 96
+        "y": 120
       },
       "id": 23,
       "options": {
@@ -4586,7 +6750,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "コスト効率",
           "mappings": [
             {
               "options": {
@@ -4627,9 +6791,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 96
+        "y": 120
       },
       "id": 31,
       "options": {
@@ -4659,7 +6823,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -4716,9 +6880,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 100
+        "y": 124
       },
       "id": 42,
       "options": {
@@ -4777,9 +6941,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 100
+        "w": 12,
+        "x": 12,
+        "y": 124
       },
       "id": 43,
       "options": {
@@ -4814,230 +6978,326 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "収穫数"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "個"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 126
+      },
+      "id": 125,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "データ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": false,
+              "ceDataOperatingTime": false,
+              "ceDataTotalStopTime": false,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "ceDataHarvestCount": "収穫数",
+              "ceDataOperatingTime": "収穫時間",
+              "ceDataTotalStopTime": "停止時間",
+              "mnDataFailureCount": "故障回数",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnDataTotalStopTime": "停止時間",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "description": "",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 1,
-        "w": 22,
+        "h": 2,
+        "w": 24,
         "x": 0,
-        "y": 102
+        "y": 130
       },
-      "id": 111,
+      "id": 152,
       "options": {
         "code": {
           "language": "plaintext",
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "",
-        "mode": "markdown"
+        "content": "<div id=\"section-safety\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
       },
       "pluginVersion": "12.0.2",
-      "title": "データ",
+      "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
+      "description": "",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "個"
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 103
-      },
-      "id": 91,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^ceDataHarvestCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "収穫数",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "分"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 103
-      },
-      "id": 89,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^ceDataOperatingTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "稼働時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "分"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 103
-      },
-      "id": 90,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^ceDataTotalStopTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "停止時間",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 106
+        "y": 132
       },
-      "id": 4,
-      "panels": [],
-      "title": "安全性",
-      "type": "row"
+      "id": 153,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>安全性</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -5092,7 +7352,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 107
+        "y": 134
       },
       "id": 24,
       "options": {
@@ -5149,7 +7409,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "安全性",
           "mappings": [
             {
               "options": {
@@ -5190,9 +7450,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 107
+        "y": 134
       },
       "id": 32,
       "options": {
@@ -5222,7 +7482,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -5279,9 +7539,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 111
+        "y": 138
       },
       "id": 44,
       "options": {
@@ -5340,9 +7600,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 111
+        "w": 12,
+        "x": 12,
+        "y": 138
       },
       "id": 45,
       "options": {
@@ -5377,168 +7637,328 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "回"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "収穫数"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "個"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 140
+      },
+      "id": 126,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "データ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": false,
+              "saDataSafetyActivationCount": false,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "ceDataHarvestCount": "収穫数",
+              "ceDataOperatingTime": "収穫時間",
+              "ceDataTotalStopTime": "停止時間",
+              "mnDataFailureCount": "故障回数",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnDataTotalStopTime": "停止時間",
+              "opDataOperationSteps": "",
+              "saDataRiskDetectionCount": "安全性リスク検知回数",
+              "saDataSafetyActivationCount": "安全装置作動回数"
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "description": "",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 1,
-        "w": 22,
+        "h": 2,
+        "w": 24,
         "x": 0,
-        "y": 113
+        "y": 144
       },
-      "id": 112,
+      "id": 155,
       "options": {
         "code": {
           "language": "plaintext",
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "",
-        "mode": "markdown"
+        "content": "<div id=\"section-data-utilization\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
       },
       "pluginVersion": "12.0.2",
-      "title": "データ",
+      "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
+      "description": "",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "回"
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 114
-      },
-      "id": 92,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^saDataRiskDetectionCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "安全性リスク検知回数",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "FY2025対象外",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "回"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 114
-      },
-      "id": 93,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^saDataSafetyActivationCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "安全装置作動回数",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 117
+        "y": 146
       },
-      "id": 3,
-      "panels": [],
-      "title": "データ活用",
-      "type": "row"
+      "id": 156,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>データ活用</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -5592,7 +8012,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 118
+        "y": 148
       },
       "id": 25,
       "options": {
@@ -5649,7 +8069,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "データ活用",
           "mappings": [
             {
               "options": {
@@ -5690,9 +8110,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 118
+        "y": 148
       },
       "id": 33,
       "options": {
@@ -5722,7 +8142,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -5779,9 +8199,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 122
+        "y": 152
       },
       "id": 46,
       "options": {
@@ -5840,9 +8260,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 122
+        "w": 12,
+        "x": 12,
+        "y": 152
       },
       "id": 47,
       "options": {
@@ -5877,17 +8297,58 @@
       "type": "stat"
     },
     {
-      "collapsed": false,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 124
+        "y": 154
       },
-      "id": 2,
-      "panels": [],
-      "title": "耐久性",
-      "type": "row"
+      "id": 157,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<div id=\"section-durability\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 156
+      },
+      "id": 158,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>耐久性</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -5941,7 +8402,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 125
+        "y": 158
       },
       "id": 26,
       "options": {
@@ -5998,7 +8459,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "耐久性",
           "mappings": [
             {
               "options": {
@@ -6039,9 +8500,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 125
+        "y": 158
       },
       "id": 34,
       "options": {
@@ -6071,7 +8532,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -6128,9 +8589,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 129
+        "y": 162
       },
       "id": 48,
       "options": {
@@ -6189,9 +8650,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 129
+        "w": 12,
+        "x": 12,
+        "y": 162
       },
       "id": 49,
       "options": {
@@ -6226,33 +8687,6 @@
       "type": "stat"
     },
     {
-      "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 22,
-        "x": 0,
-        "y": 131
-      },
-      "id": 113,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "markdown"
-      },
-      "pluginVersion": "12.0.2",
-      "title": "メトリクス",
-      "transparent": true,
-      "type": "text"
-    },
-    {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
@@ -6263,71 +8697,13 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red"
-              },
-              {
-                "color": "green",
-                "value": 9.5
-              }
-            ]
-          },
-          "unit": "時間"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 132
-      },
-      "id": 94,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^dbMetricsMtbf$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "MTBF",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
           },
           "mappings": [],
           "thresholds": {
@@ -6344,31 +8720,54 @@
           },
           "unit": "percent"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MTBF"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "時間"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red"
+                    },
+                    {
+                      "color": "green",
+                      "value": 9.5
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 132
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 164
       },
-      "id": 95,
+      "id": 128,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^dbMetricsOperationRate$/",
-          "values": false
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -6381,8 +8780,566 @@
           "refId": "A"
         }
       ],
-      "title": "稼働率",
-      "type": "stat"
+      "title": "メトリクス",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": false,
+              "dbMetricsOperationRate": false,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 19,
+              "dbDataOperatingTime": 17,
+              "dbDataProcessingTime": 20,
+              "dbDataRobotSpeed": 21,
+              "dbDataStatusCode": 22,
+              "dbDataTotalStopTime": 18,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "ceDataHarvestCount": "収穫数",
+              "ceDataOperatingTime": "収穫時間",
+              "ceDataTotalStopTime": "停止時間",
+              "dbDataFailureCount": "故障回数",
+              "dbDataOperatingTime": "稼働時間",
+              "dbDataProcessingTime": "1果実あたりの処理時間",
+              "dbDataRobotSpeed": "ロボット走行速度",
+              "dbDataStatusCode": "ロボットステータス",
+              "dbDataTotalStopTime": "停止時間",
+              "dbMetricsMtbf": "MTBF",
+              "dbMetricsOperationRate": "稼働率",
+              "mnDataFailureCount": "故障回数",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnDataTotalStopTime": "停止時間",
+              "opDataOperationSteps": "",
+              "saDataRiskDetectionCount": "安全性リスク検知回数",
+              "saDataSafetyActivationCount": "安全装置作動回数"
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false,
+            "width": 170
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "故障回数"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "回"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1果実あたりの処理時間"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "秒"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ロボット走行速度"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "velocityms"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ロボットステータス"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "E-01": {
+                        "index": 9,
+                        "text": "バッテリー残量低下"
+                      },
+                      "H-01": {
+                        "index": 7,
+                        "text": "視界不良"
+                      },
+                      "H-02": {
+                        "index": 8,
+                        "text": "収穫物満タン"
+                      },
+                      "R-01": {
+                        "index": 4,
+                        "text": "足元スタック"
+                      },
+                      "R-02": {
+                        "index": 5,
+                        "text": "進路妨害"
+                      },
+                      "R-03": {
+                        "index": 6,
+                        "text": "脱輪・転倒"
+                      },
+                      "S-01": {
+                        "index": 0,
+                        "text": "待機中"
+                      },
+                      "S-02": {
+                        "index": 1,
+                        "text": "移動中"
+                      },
+                      "S-03": {
+                        "index": 2,
+                        "text": "収穫中"
+                      },
+                      "S-04": {
+                        "index": 3,
+                        "text": "帰還中"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 168
+      },
+      "id": 127,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "データ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": false,
+              "dbDataOperatingTime": false,
+              "dbDataProcessingTime": false,
+              "dbDataRobotSpeed": false,
+              "dbDataStatusCode": false,
+              "dbDataTotalStopTime": false,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataPartFailureProbsArm": true,
+              "mnDataPartFailureProbsCamera": true,
+              "mnDataPartFailureProbsCommunication": true,
+              "mnDataPartFailureProbsControlUnit": true,
+              "mnDataPartFailureProbsHand": true,
+              "mnDataPartFailureProbsPower": true,
+              "mnDataPartFailureProbsTray": true,
+              "mnDataPartFailureProbsWheels": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 19,
+              "dbDataOperatingTime": 17,
+              "dbDataProcessingTime": 20,
+              "dbDataRobotSpeed": 21,
+              "dbDataStatusCode": 22,
+              "dbDataTotalStopTime": 18,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "ceDataHarvestCount": "収穫数",
+              "ceDataOperatingTime": "収穫時間",
+              "ceDataTotalStopTime": "停止時間",
+              "dbDataFailureCount": "故障回数",
+              "dbDataOperatingTime": "稼働時間",
+              "dbDataProcessingTime": "1果実あたりの処理時間",
+              "dbDataRobotSpeed": "ロボット走行速度",
+              "dbDataStatusCode": "ロボットステータス",
+              "dbDataTotalStopTime": "停止時間",
+              "mnDataFailureCount": "故障回数",
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "mnDataTotalStopTime": "停止時間",
+              "opDataOperationSteps": "",
+              "saDataRiskDetectionCount": "安全性リスク検知回数",
+              "saDataSafetyActivationCount": "安全装置作動回数"
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "description": "",
@@ -6391,455 +9348,52 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 1,
-        "w": 22,
+        "h": 2,
+        "w": 24,
         "x": 0,
-        "y": 135
+        "y": 172
       },
-      "id": 114,
+      "id": 160,
       "options": {
         "code": {
           "language": "plaintext",
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "",
-        "mode": "markdown"
+        "content": "<div id=\"section-ethics\" style=\"position: relative; top: -80px;\"></div>",
+        "mode": "html"
       },
       "pluginVersion": "12.0.2",
-      "title": "データ",
+      "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "分"
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 136
-      },
-      "id": 96,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^dbDataOperatingTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "稼働時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "分"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 136
-      },
-      "id": 97,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^dbDataTotalStopTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "停止時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "回"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 136
-      },
-      "id": 98,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^dbDataFailureCount$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "故障回数",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "秒"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 136
-      },
-      "id": 99,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^dbDataProcessingTime$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "1果実あたりの処理時間",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "velocityms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 136
-      },
-      "id": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^dbDataRobotSpeed$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "ロボット走行速度",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [
-            {
-              "options": {
-                "E-01": {
-                  "index": 9,
-                  "text": "バッテリー残量低下"
-                },
-                "H-01": {
-                  "index": 7,
-                  "text": "視界不良"
-                },
-                "H-02": {
-                  "index": 8,
-                  "text": "収穫物満タン"
-                },
-                "R-01": {
-                  "index": 4,
-                  "text": "足元スタック"
-                },
-                "R-02": {
-                  "index": 5,
-                  "text": "進路妨害"
-                },
-                "R-03": {
-                  "index": 6,
-                  "text": "脱輪・転倒"
-                },
-                "S-01": {
-                  "index": 0,
-                  "text": "待機中"
-                },
-                "S-02": {
-                  "index": 1,
-                  "text": "移動中"
-                },
-                "S-03": {
-                  "index": 2,
-                  "text": "収穫中"
-                },
-                "S-04": {
-                  "index": 3,
-                  "text": "帰還中"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 136
-      },
-      "id": 101,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^dbDataStatusCode$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "ロボットステータス",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 139
+        "y": 174
       },
-      "id": 1,
-      "panels": [],
-      "title": "倫理性",
-      "type": "row"
+      "id": 159,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h2>倫理性</h2>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
@@ -6894,7 +9448,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 140
+        "y": 176
       },
       "id": 27,
       "options": {
@@ -6951,7 +9505,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
-          "displayName": "収穫精度",
+          "displayName": "倫理性",
           "mappings": [
             {
               "options": {
@@ -6992,9 +9546,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 19,
+        "w": 21,
         "x": 3,
-        "y": 140
+        "y": 176
       },
       "id": 35,
       "options": {
@@ -7024,7 +9578,7 @@
           "refId": "A"
         }
       ],
-      "title": "評価",
+      "title": "評価の推移",
       "transformations": [
         {
           "id": "convertFieldType",
@@ -7081,9 +9635,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 144
+        "y": 180
       },
       "id": 50,
       "options": {
@@ -7142,9 +9696,9 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 11,
-        "x": 11,
-        "y": 144
+        "w": 12,
+        "x": 12,
+        "y": 180
       },
       "id": 51,
       "options": {
@@ -7194,5 +9748,5 @@
   "timezone": "browser",
   "title": "第三者評価",
   "uid": "510b40ad-9b16-4918-907f-63bfd9ac162c",
-  "version": 4
+  "version": 13
 }

--- a/grafana/dashboards/3rdPartyEvaluation.json
+++ b/grafana/dashboards/3rdPartyEvaluation.json
@@ -1914,7 +1914,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
@@ -4229,71 +4229,12 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 88
-      },
-      "id": 79,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataPartFailureProbsArm$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "予兆発生率（アーム）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4313,292 +4254,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 88
-      },
-      "id": 80,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataPartFailureProbsHand$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "予兆発生率（ハンド）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 88
-      },
-      "id": 81,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataPartFailureProbsCamera$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "予兆発生率（カメラ）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 88
-      },
-      "id": 82,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataPartFailureProbsWheels$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "予兆発生率（車輪）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 88
-      },
-      "id": 85,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataPartFailureProbsTray$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "予兆発生率（トレイ）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
+        "h": 4,
+        "w": 22,
         "x": 0,
         "y": 91
       },
-      "id": 86,
+      "id": 115,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^mnDataPartFailureProbsCommunication$/",
-          "values": false
+          "show": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -4611,140 +4283,185 @@
           "refId": "A"
         }
       ],
-      "title": "予兆発生率（通信）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
+      "title": "予兆発生率",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "adAction": true,
+              "adDataCo2": true,
+              "adDataHumidity": true,
+              "adDataIlluminance": true,
+              "adDataPitch": true,
+              "adDataRoll": true,
+              "adDataTemperature": true,
+              "adDataYaw": true,
+              "adDiagnosis": true,
+              "adStatus": true,
+              "ceAction": true,
+              "ceDataHarvestCount": true,
+              "ceDataOperatingTime": true,
+              "ceDataTotalStopTime": true,
+              "ceDiagnosis": true,
+              "ceStatus": true,
+              "dbAction": true,
+              "dbDataFailureCount": true,
+              "dbDataOperatingTime": true,
+              "dbDataProcessingTime": true,
+              "dbDataRobotSpeed": true,
+              "dbDataStatusCode": true,
+              "dbDataTotalStopTime": true,
+              "dbDiagnosis": true,
+              "dbMetricsMtbf": true,
+              "dbMetricsOperationRate": true,
+              "dbStatus": true,
+              "duAction": true,
+              "duDiagnosis": true,
+              "duStatus": true,
+              "etAction": true,
+              "etDiagnosis": true,
+              "etStatus": true,
+              "haAction": true,
+              "haDataDetectionCount": true,
+              "haDataHarvestCount": true,
+              "haDiagnosis": true,
+              "haMetricsAmbiguityRate": true,
+              "haMetricsUncertainCount": true,
+              "haStatus": true,
+              "hsAction": true,
+              "hsDataOperatingTime": true,
+              "hsDataProcessingTime": true,
+              "hsDataRobotSpeed": true,
+              "hsDataStatusCode": true,
+              "hsDataTravelStopTime": true,
+              "hsDiagnosis": true,
+              "hsMetricsStopRate": true,
+              "hsStatus": true,
+              "mnAction": true,
+              "mnDataFailureCount": true,
+              "mnDataTotalStopTime": true,
+              "mnDiagnosis": true,
+              "mnMetricsMttr": true,
+              "mnStatus": true,
+              "opAction": true,
+              "opDataOperationErrors": true,
+              "opDataOperationSteps": true,
+              "opDataOperationTime": true,
+              "opDiagnosis": true,
+              "opMetricsOperationErrorRate": true,
+              "opStatus": true,
+              "saAction": true,
+              "saDataRiskDetectionCount": true,
+              "saDataSafetyActivationCount": true,
+              "saDiagnosis": true,
+              "saStatus": true,
+              "timestamp": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "adAction": 0,
+              "adDataCo2": 1,
+              "adDataHumidity": 2,
+              "adDataIlluminance": 3,
+              "adDataPitch": 4,
+              "adDataRoll": 5,
+              "adDataTemperature": 6,
+              "adDataYaw": 7,
+              "adDiagnosis": 8,
+              "adStatus": 9,
+              "ceAction": 10,
+              "ceDataHarvestCount": 11,
+              "ceDataOperatingTime": 12,
+              "ceDataTotalStopTime": 13,
+              "ceDiagnosis": 14,
+              "ceStatus": 15,
+              "dbAction": 16,
+              "dbDataFailureCount": 17,
+              "dbDataOperatingTime": 18,
+              "dbDataProcessingTime": 19,
+              "dbDataRobotSpeed": 20,
+              "dbDataStatusCode": 21,
+              "dbDataTotalStopTime": 22,
+              "dbDiagnosis": 23,
+              "dbMetricsMtbf": 24,
+              "dbMetricsOperationRate": 25,
+              "dbStatus": 26,
+              "duAction": 27,
+              "duDiagnosis": 28,
+              "duStatus": 29,
+              "etAction": 30,
+              "etDiagnosis": 31,
+              "etStatus": 32,
+              "haAction": 33,
+              "haDataDetectionCount": 34,
+              "haDataHarvestCount": 35,
+              "haDiagnosis": 36,
+              "haMetricsAmbiguityRate": 37,
+              "haMetricsUncertainCount": 38,
+              "haStatus": 39,
+              "hsAction": 40,
+              "hsDataOperatingTime": 41,
+              "hsDataProcessingTime": 42,
+              "hsDataRobotSpeed": 43,
+              "hsDataStatusCode": 44,
+              "hsDataTravelStopTime": 45,
+              "hsDiagnosis": 46,
+              "hsMetricsStopRate": 47,
+              "hsStatus": 48,
+              "mnAction": 49,
+              "mnDataFailureCount": 50,
+              "mnDataPartFailureProbsArm": 51,
+              "mnDataPartFailureProbsCamera": 53,
+              "mnDataPartFailureProbsCommunication": 56,
+              "mnDataPartFailureProbsControlUnit": 57,
+              "mnDataPartFailureProbsHand": 52,
+              "mnDataPartFailureProbsPower": 58,
+              "mnDataPartFailureProbsTray": 55,
+              "mnDataPartFailureProbsWheels": 54,
+              "mnDataTotalStopTime": 59,
+              "mnDiagnosis": 60,
+              "mnMetricsMttr": 61,
+              "mnStatus": 62,
+              "opAction": 63,
+              "opDataOperationErrors": 64,
+              "opDataOperationSteps": 65,
+              "opDataOperationTime": 66,
+              "opDiagnosis": 67,
+              "opMetricsOperationErrorRate": 68,
+              "opStatus": 69,
+              "saAction": 70,
+              "saDataRiskDetectionCount": 71,
+              "saDataSafetyActivationCount": 72,
+              "saDiagnosis": 73,
+              "saStatus": 74,
+              "timestamp": 75
+            },
+            "renameByName": {
+              "mnDataPartFailureProbsArm": "アーム",
+              "mnDataPartFailureProbsCamera": "カメラ",
+              "mnDataPartFailureProbsCommunication": "通信",
+              "mnDataPartFailureProbsControlUnit": "制御ユニット",
+              "mnDataPartFailureProbsHand": "ハンド",
+              "mnDataPartFailureProbsPower": "電源",
+              "mnDataPartFailureProbsTray": "トレイ",
+              "mnDataPartFailureProbsWheels": "車輪",
+              "opDataOperationSteps": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "lastNotNull"
             ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 91
-      },
-      "id": 87,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataPartFailureProbsControlUnit$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
+          }
         }
       ],
-      "title": "予兆発生率（制御ユニット）",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 91
-      },
-      "id": 88,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mnDataPartFailureProbsPower$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 11,
-          "refId": "A"
-        }
-      ],
-      "title": "予兆発生率（電源）",
-      "type": "stat"
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -4752,7 +4469,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 95
       },
       "id": 5,
       "panels": [],
@@ -4812,7 +4529,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 95
+        "y": 96
       },
       "id": 23,
       "options": {
@@ -4912,7 +4629,7 @@
         "h": 4,
         "w": 19,
         "x": 3,
-        "y": 95
+        "y": 96
       },
       "id": 31,
       "options": {
@@ -5001,7 +4718,7 @@
         "h": 2,
         "w": 11,
         "x": 0,
-        "y": 99
+        "y": 100
       },
       "id": 42,
       "options": {
@@ -5062,7 +4779,7 @@
         "h": 2,
         "w": 11,
         "x": 11,
-        "y": 99
+        "y": 100
       },
       "id": 43,
       "options": {
@@ -5106,7 +4823,7 @@
         "h": 1,
         "w": 22,
         "x": 0,
-        "y": 101
+        "y": 102
       },
       "id": 111,
       "options": {
@@ -5151,7 +4868,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 102
+        "y": 103
       },
       "id": 91,
       "options": {
@@ -5213,7 +4930,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 102
+        "y": 103
       },
       "id": 89,
       "options": {
@@ -5275,7 +4992,7 @@
         "h": 3,
         "w": 3,
         "x": 6,
-        "y": 102
+        "y": 103
       },
       "id": 90,
       "options": {
@@ -5315,7 +5032,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 106
       },
       "id": 4,
       "panels": [],
@@ -5375,7 +5092,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 106
+        "y": 107
       },
       "id": 24,
       "options": {
@@ -5475,7 +5192,7 @@
         "h": 4,
         "w": 19,
         "x": 3,
-        "y": 106
+        "y": 107
       },
       "id": 32,
       "options": {
@@ -5564,7 +5281,7 @@
         "h": 2,
         "w": 11,
         "x": 0,
-        "y": 110
+        "y": 111
       },
       "id": 44,
       "options": {
@@ -5625,7 +5342,7 @@
         "h": 2,
         "w": 11,
         "x": 11,
-        "y": 110
+        "y": 111
       },
       "id": 45,
       "options": {
@@ -5669,7 +5386,7 @@
         "h": 1,
         "w": 22,
         "x": 0,
-        "y": 112
+        "y": 113
       },
       "id": 112,
       "options": {
@@ -5714,7 +5431,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 113
+        "y": 114
       },
       "id": 92,
       "options": {
@@ -5776,7 +5493,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 113
+        "y": 114
       },
       "id": 93,
       "options": {
@@ -5816,7 +5533,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 116
+        "y": 117
       },
       "id": 3,
       "panels": [],
@@ -5875,7 +5592,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 117
+        "y": 118
       },
       "id": 25,
       "options": {
@@ -5975,7 +5692,7 @@
         "h": 4,
         "w": 19,
         "x": 3,
-        "y": 117
+        "y": 118
       },
       "id": 33,
       "options": {
@@ -6064,7 +5781,7 @@
         "h": 2,
         "w": 11,
         "x": 0,
-        "y": 121
+        "y": 122
       },
       "id": 46,
       "options": {
@@ -6125,7 +5842,7 @@
         "h": 2,
         "w": 11,
         "x": 11,
-        "y": 121
+        "y": 122
       },
       "id": 47,
       "options": {
@@ -6165,7 +5882,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 123
+        "y": 124
       },
       "id": 2,
       "panels": [],
@@ -6224,7 +5941,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 124
+        "y": 125
       },
       "id": 26,
       "options": {
@@ -6324,7 +6041,7 @@
         "h": 4,
         "w": 19,
         "x": 3,
-        "y": 124
+        "y": 125
       },
       "id": 34,
       "options": {
@@ -6413,7 +6130,7 @@
         "h": 2,
         "w": 11,
         "x": 0,
-        "y": 128
+        "y": 129
       },
       "id": 48,
       "options": {
@@ -6474,7 +6191,7 @@
         "h": 2,
         "w": 11,
         "x": 11,
-        "y": 128
+        "y": 129
       },
       "id": 49,
       "options": {
@@ -6518,7 +6235,7 @@
         "h": 1,
         "w": 22,
         "x": 0,
-        "y": 130
+        "y": 131
       },
       "id": 113,
       "options": {
@@ -6567,7 +6284,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 131
+        "y": 132
       },
       "id": 94,
       "options": {
@@ -6633,7 +6350,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 131
+        "y": 132
       },
       "id": 95,
       "options": {
@@ -6677,7 +6394,7 @@
         "h": 1,
         "w": 22,
         "x": 0,
-        "y": 134
+        "y": 135
       },
       "id": 114,
       "options": {
@@ -6722,7 +6439,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 135
+        "y": 136
       },
       "id": 96,
       "options": {
@@ -6784,7 +6501,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 135
+        "y": 136
       },
       "id": 97,
       "options": {
@@ -6846,7 +6563,7 @@
         "h": 3,
         "w": 3,
         "x": 6,
-        "y": 135
+        "y": 136
       },
       "id": 98,
       "options": {
@@ -6908,7 +6625,7 @@
         "h": 3,
         "w": 3,
         "x": 9,
-        "y": 135
+        "y": 136
       },
       "id": 99,
       "options": {
@@ -6970,7 +6687,7 @@
         "h": 3,
         "w": 3,
         "x": 12,
-        "y": 135
+        "y": 136
       },
       "id": 100,
       "options": {
@@ -7077,7 +6794,7 @@
         "h": 3,
         "w": 3,
         "x": 15,
-        "y": 135
+        "y": 136
       },
       "id": 101,
       "options": {
@@ -7117,7 +6834,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 138
+        "y": 139
       },
       "id": 1,
       "panels": [],
@@ -7177,7 +6894,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 139
+        "y": 140
       },
       "id": 27,
       "options": {
@@ -7277,7 +6994,7 @@
         "h": 4,
         "w": 19,
         "x": 3,
-        "y": 139
+        "y": 140
       },
       "id": 35,
       "options": {
@@ -7366,7 +7083,7 @@
         "h": 2,
         "w": 11,
         "x": 0,
-        "y": 143
+        "y": 144
       },
       "id": 50,
       "options": {
@@ -7427,7 +7144,7 @@
         "h": 2,
         "w": 11,
         "x": 11,
-        "y": 143
+        "y": 144
       },
       "id": 51,
       "options": {
@@ -7477,5 +7194,5 @@
   "timezone": "browser",
   "title": "第三者評価",
   "uid": "510b40ad-9b16-4918-907f-63bfd9ac162c",
-  "version": 10
+  "version": 4
 }

--- a/grafana/dashboards/3rdPartyEvaluation.json
+++ b/grafana/dashboards/3rdPartyEvaluation.json
@@ -29,9 +29,9 @@
         "x": 0,
         "y": 0
       },
-      "id": 4,
+      "id": 10,
       "panels": [],
-      "title": "総合",
+      "title": "収穫精度",
       "type": "row"
     },
     {
@@ -39,6 +39,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "P0DB2B379060E8607"
       },
+      "description": "FY2025対象外",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -58,7 +59,7 @@
                   "text": "正常"
                 },
                 "unknown": {
-                  "color": "purple",
+                  "color": "#808080",
                   "index": 3,
                   "text": "不明"
                 },
@@ -83,12 +84,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 5,
+        "h": 4,
+        "w": 3,
         "x": 0,
         "y": 1
       },
-      "id": 1,
+      "id": 11,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -99,7 +100,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^systemHealth$/",
+          "fields": "/^haStatus$/",
           "values": false
         },
         "showPercentChange": false,
@@ -110,16 +111,12 @@
       "targets": [
         {
           "columns": [],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "P0DB2B379060E8607"
-          },
           "filters": [],
           "format": "table",
           "global_query_id": "",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "(\n    $ts := $.attributes[attrName = \"systemTimestamp\"].values;\n    $systemHealth := $.attributes[attrName = \"analysis\"].values.system.health;\n    $houseHealth := $.attributes[attrName = \"analysis\"].values.house.health;\n    $houseAction := $.attributes[attrName = \"analysis\"].values.house.action;\n    $houseDiagnosis := $.attributes[attrName = \"analysis\"].values.house.diagnosis;\n    $houseProblematicData := $.attributes[attrName = \"analysis\"].values.house.problematicData;\n    $robotHealth := $.attributes[attrName = \"analysis\"].values.robot.health;\n    $robotAction := $.attributes[attrName = \"analysis\"].values.robot.action;\n    $robotDiagnosis := $.attributes[attrName = \"analysis\"].values.robot.diagnosis;\n    $houseCo2 := $.attributes[attrName = \"house\"].values.co2;\n    $houseIlluminance := $.attributes[attrName = \"house\"].values.illuminance;\n    $houseRelativeHumidity := $.attributes[attrName = \"house\"].values.relativeHumidity;\n    $houseTemperature := $.attributes[attrName = \"house\"].values.temperature;\n    $robotBatteryLevel := $.attributes[attrName = \"robot\"].values.batteryLevel;\n    $robotCameraClarity := $.attributes[attrName = \"robot\"].values.cameraClarity;\n    $robotObstacleDetected := $.attributes[attrName = \"robot\"].values.obstacleDetected;\n    $robotPitch := $.attributes[attrName = \"robot\"].values.pitch;\n    $robotRoll = $.attributes[attrName = \"robot\"].values.roll;\n    $robotSpeed := $.attributes[attrName = \"robot\"].values.speed;\n    $robotStatus := $.attributes[attrName = \"robot\"].values.status;\n    $robotTireRotation := $.attributes[attrName = \"robot\"].values.tireRotation;\n    $robotTrayFull := $.attributes[attrName = \"robot\"].values.trayFull;\n\n    $map($ts, function($v, $i) {\n        {\n            \"timestamp\": $v,\n            \"systemHealth\": $systemHealth[$i],\n            \"houseHealth\": $houseHealth[$i],\n            \"houseAction\": $houseAction[$i],\n            \"houseDiagnosis\": $houseDiagnosis[$i],\n            \"robotHealth\": $robotHealth[$i],\n            \"robotAction\": $robotAction[$i],\n            \"robotDiagnosis\": $robotDiagnosis[$i],\n            \"houseCo2\": $houseCo2[$i],\n            \"houseIlluminance\": $houseIlluminance[$i],\n            \"houseRelativeHumidity\": $houseRelativeHumidity[$i],\n            \"houseTemperature\": $houseTemperature[$i],\n            \"robotBatteryLevel\": $robotBatteryLevel[$i],\n            \"robotCameraClarity\": $robotCameraClarity[$i],\n            \"robotObstacleDetected\": $robotObstacleDetected[$i],\n            \"robotPitch\": $robotPitch[$i],\n            \"robotRoll\": $robotRoll[$i],\n            \"robotSpeed\": $robotSpeed[$i],\n            \"robotStatus\": $robotStatus[$i],\n            \"robotTireRotation\": $robotTireRotation[$i],\n            \"robotTrayFull\": $robotTrayFull[$i]\n        }\n    })\n)",
+          "root_selector": "(\n  /* タイムスタンプ */\n  $ts := $.attributes[attrName = \"systemTimestamp\"].values;\n\n  /* adaptability (ad) */\n  $adAction := $.attributes[attrName = \"analysis\"].values.adaptability.action;\n  $adDataCo2 := $.attributes[attrName = \"analysis\"].values.adaptability.data.co2;\n  $adDataHumidity := $.attributes[attrName = \"analysis\"].values.adaptability.data.humidity;\n  $adDataIlluminance := $.attributes[attrName = \"analysis\"].values.adaptability.data.illuminance;\n  $adDataPitch := $.attributes[attrName = \"analysis\"].values.adaptability.data.pitch;\n  $adDataRoll := $.attributes[attrName = \"analysis\"].values.adaptability.data.roll;\n  $adDataTemperature := $.attributes[attrName = \"analysis\"].values.adaptability.data.temperature;\n  $adDataYaw := $.attributes[attrName = \"analysis\"].values.adaptability.data.yaw;\n  $adDiagnosis := $.attributes[attrName = \"analysis\"].values.adaptability.diagnosis;\n  $adStatus := $.attributes[attrName = \"analysis\"].values.adaptability.status;\n\n  /* costEfficiency (ce) */\n  $ceAction := $.attributes[attrName = \"analysis\"].values.costEfficiency.action;\n  $ceDataHarvestCount := $.attributes[attrName = \"analysis\"].values.costEfficiency.data.harvestCount;\n  $ceDataOperatingTime := $.attributes[attrName = \"analysis\"].values.costEfficiency.data.operatingTime;\n  $ceDataTotalStopTime := $.attributes[attrName = \"analysis\"].values.costEfficiency.data.totalStopTime;\n  $ceDiagnosis := $.attributes[attrName = \"analysis\"].values.costEfficiency.diagnosis;\n  $ceStatus := $.attributes[attrName = \"analysis\"].values.costEfficiency.status;\n\n  /* dataUtilization (du) */\n  $duAction := $.attributes[attrName = \"analysis\"].values.dataUtilization.action;\n  $duDiagnosis := $.attributes[attrName = \"analysis\"].values.dataUtilization.diagnosis;\n  $duStatus := $.attributes[attrName = \"analysis\"].values.dataUtilization.status;\n\n  /* durability (db) */\n  $dbAction := $.attributes[attrName = \"analysis\"].values.durability.action;\n  $dbDataFailureCount := $.attributes[attrName = \"analysis\"].values.durability.data.failureCount;\n  $dbDataOperatingTime := $.attributes[attrName = \"analysis\"].values.durability.data.operatingTime;\n  $dbDataProcessingTime := $.attributes[attrName = \"analysis\"].values.durability.data.processingTime;\n  $dbDataRobotSpeed := $.attributes[attrName = \"analysis\"].values.durability.data.robotSpeed;\n  $dbDataStatusCode := $.attributes[attrName = \"analysis\"].values.durability.data.statusCode;\n  $dbDataTotalStopTime := $.attributes[attrName = \"analysis\"].values.durability.data.totalStopTime;\n  $dbDiagnosis := $.attributes[attrName = \"analysis\"].values.durability.diagnosis;\n  $dbMetricsMtbf := $.attributes[attrName = \"analysis\"].values.durability.metrics.mtbf;\n  $dbMetricsOperationRate := $.attributes[attrName = \"analysis\"].values.durability.metrics.operationRate;\n  $dbStatus := $.attributes[attrName = \"analysis\"].values.durability.status;\n\n  /* ethics (et) */\n  $etAction := $.attributes[attrName = \"analysis\"].values.ethics.action;\n  $etDiagnosis := $.attributes[attrName = \"analysis\"].values.ethics.diagnosis;\n  $etStatus := $.attributes[attrName = \"analysis\"].values.ethics.status;\n\n  /* harvestAccuracy (ha) */\n  $haAction := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.action;\n  $haDataDetectionCount := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.data.detectionCount;\n  $haDataHarvestCount := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.data.harvestCount;\n  $haDiagnosis := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.diagnosis;\n  $haMetricsAmbiguityRate := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.metrics.ambiguityRate;\n  $haMetricsUncertainCount := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.metrics.uncertainCount;\n  $haStatus := $.attributes[attrName = \"analysis\"].values.harvestAccuracy.status;\n\n  /* harvestSpeed (hs) */\n  $hsAction := $.attributes[attrName = \"analysis\"].values.harvestSpeed.action;\n  $hsDataOperatingTime := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.operatingTime;\n  $hsDataProcessingTime := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.processingTime;\n  $hsDataRobotSpeed := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.robotSpeed;\n  $hsDataStatusCode := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.statusCode;\n  $hsDataTravelStopTime := $.attributes[attrName = \"analysis\"].values.harvestSpeed.data.travelStopTime;\n  $hsDiagnosis := $.attributes[attrName = \"analysis\"].values.harvestSpeed.diagnosis;\n  $hsMetricsStopRate := $.attributes[attrName = \"analysis\"].values.harvestSpeed.metrics.stopRate;\n  $hsStatus := $.attributes[attrName = \"analysis\"].values.harvestSpeed.status;\n\n  /* maintainability (mn) */\n  $mnAction := $.attributes[attrName = \"analysis\"].values.maintainability.action;\n  $mnDataFailureCount := $.attributes[attrName = \"analysis\"].values.maintainability.data.failureCount;\n  $mnDataPartFailureProbsArm := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.arm;\n  $mnDataPartFailureProbsCamera := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.camera;\n  $mnDataPartFailureProbsCommunication := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.communication;\n  $mnDataPartFailureProbsControlUnit := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.controlUnit;\n  $mnDataPartFailureProbsHand := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.hand;\n  $mnDataPartFailureProbsPower := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.power;\n  $mnDataPartFailureProbsTray := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.tray;\n  $mnDataPartFailureProbsWheels := $.attributes[attrName = \"analysis\"].values.maintainability.data.partFailureProbs.wheels;\n  $mnDataTotalStopTime := $.attributes[attrName = \"analysis\"].values.maintainability.data.totalStopTime;\n  $mnDiagnosis := $.attributes[attrName = \"analysis\"].values.maintainability.diagnosis;\n  $mnMetricsMttr := $.attributes[attrName = \"analysis\"].values.maintainability.metrics.mttr;\n  $mnStatus := $.attributes[attrName = \"analysis\"].values.maintainability.status;\n\n  /* operability (op) */\n  $opAction := $.attributes[attrName = \"analysis\"].values.operability.action;\n  $opDataOperationErrors := $.attributes[attrName = \"analysis\"].values.operability.data.operationErrors;\n  $opDataOperationSteps := $.attributes[attrName = \"analysis\"].values.operability.data.operationSteps;\n  $opDataOperationTime := $.attributes[attrName = \"analysis\"].values.operability.data.operationTime;\n  $opDiagnosis := $.attributes[attrName = \"analysis\"].values.operability.diagnosis;\n  $opMetricsOperationErrorRate := $.attributes[attrName = \"analysis\"].values.operability.metrics.operationErrorRate;\n  $opStatus := $.attributes[attrName = \"analysis\"].values.operability.status;\n\n  /* safety (sa) */\n  $saAction := $.attributes[attrName = \"analysis\"].values.safety.action;\n  $saDataRiskDetectionCount := $.attributes[attrName = \"analysis\"].values.safety.data.riskDetectionCount;\n  $saDataSafetyActivationCount := $.attributes[attrName = \"analysis\"].values.safety.data.safetyActivationCount;\n  $saDiagnosis := $.attributes[attrName = \"analysis\"].values.safety.diagnosis;\n  $saStatus := $.attributes[attrName = \"analysis\"].values.safety.status;\n\n  /* 出力 */\n  $map($ts, function($v, $i) {\n    {\n      \"timestamp\": $v,\n\n      /* ad */\n      \"adAction\": $adAction[$i],\n      \"adDataCo2\": $adDataCo2[$i],\n      \"adDataHumidity\": $adDataHumidity[$i],\n      \"adDataIlluminance\": $adDataIlluminance[$i],\n      \"adDataPitch\": $adDataPitch[$i],\n      \"adDataRoll\": $adDataRoll[$i],\n      \"adDataTemperature\": $adDataTemperature[$i],\n      \"adDataYaw\": $adDataYaw[$i],\n      \"adDiagnosis\": $adDiagnosis[$i],\n      \"adStatus\": $adStatus[$i],\n\n      /* ce */\n      \"ceAction\": $ceAction[$i],\n      \"ceDataHarvestCount\": $ceDataHarvestCount[$i],\n      \"ceDataOperatingTime\": $ceDataOperatingTime[$i],\n      \"ceDataTotalStopTime\": $ceDataTotalStopTime[$i],\n      \"ceDiagnosis\": $ceDiagnosis[$i],\n      \"ceStatus\": $ceStatus[$i],\n\n      /* du */\n      \"duAction\": $duAction[$i],\n      \"duDiagnosis\": $duDiagnosis[$i],\n      \"duStatus\": $duStatus[$i],\n\n      /* db */\n      \"dbAction\": $dbAction[$i],\n      \"dbDataFailureCount\": $dbDataFailureCount[$i],\n      \"dbDataOperatingTime\": $dbDataOperatingTime[$i],\n      \"dbDataProcessingTime\": $dbDataProcessingTime[$i],\n      \"dbDataRobotSpeed\": $dbDataRobotSpeed[$i],\n      \"dbDataStatusCode\": $dbDataStatusCode[$i],\n      \"dbDataTotalStopTime\": $dbDataTotalStopTime[$i],\n      \"dbDiagnosis\": $dbDiagnosis[$i],\n      \"dbMetricsMtbf\": $dbMetricsMtbf[$i],\n      \"dbMetricsOperationRate\": $dbMetricsOperationRate[$i],\n      \"dbStatus\": $dbStatus[$i],\n\n      /* et */\n      \"etAction\": $etAction[$i],\n      \"etDiagnosis\": $etDiagnosis[$i],\n      \"etStatus\": $etStatus[$i],\n\n      /* ha */\n      \"haAction\": $haAction[$i],\n      \"haDataDetectionCount\": $haDataDetectionCount[$i],\n      \"haDataHarvestCount\": $haDataHarvestCount[$i],\n      \"haDiagnosis\": $haDiagnosis[$i],\n      \"haMetricsAmbiguityRate\": $haMetricsAmbiguityRate[$i],\n      \"haMetricsUncertainCount\": $haMetricsUncertainCount[$i],\n      \"haStatus\": $haStatus[$i],\n\n      /* hs */\n      \"hsAction\": $hsAction[$i],\n      \"hsDataOperatingTime\": $hsDataOperatingTime[$i],\n      \"hsDataProcessingTime\": $hsDataProcessingTime[$i],\n      \"hsDataRobotSpeed\": $hsDataRobotSpeed[$i],\n      \"hsDataStatusCode\": $hsDataStatusCode[$i],\n      \"hsDataTravelStopTime\": $hsDataTravelStopTime[$i],\n      \"hsDiagnosis\": $hsDiagnosis[$i],\n      \"hsMetricsStopRate\": $hsMetricsStopRate[$i],\n      \"hsStatus\": $hsStatus[$i],\n\n      /* mn */\n      \"mnAction\": $mnAction[$i],\n      \"mnDataFailureCount\": $mnDataFailureCount[$i],\n      \"mnDataPartFailureProbsArm\": $mnDataPartFailureProbsArm[$i],\n      \"mnDataPartFailureProbsCamera\": $mnDataPartFailureProbsCamera[$i],\n      \"mnDataPartFailureProbsCommunication\": $mnDataPartFailureProbsCommunication[$i],\n      \"mnDataPartFailureProbsControlUnit\": $mnDataPartFailureProbsControlUnit[$i],\n      \"mnDataPartFailureProbsHand\": $mnDataPartFailureProbsHand[$i],\n      \"mnDataPartFailureProbsPower\": $mnDataPartFailureProbsPower[$i],\n      \"mnDataPartFailureProbsTray\": $mnDataPartFailureProbsTray[$i],\n      \"mnDataPartFailureProbsWheels\": $mnDataPartFailureProbsWheels[$i],\n      \"mnDataTotalStopTime\": $mnDataTotalStopTime[$i],\n      \"mnDiagnosis\": $mnDiagnosis[$i],\n      \"mnMetricsMttr\": $mnMetricsMttr[$i],\n      \"mnStatus\": $mnStatus[$i],\n\n      /* op */\n      \"opAction\": $opAction[$i],\n      \"opDataOperationErrors\": $opDataOperationErrors[$i],\n      \"opDataOperationSteps\": $opDataOperationSteps[$i],\n      \"opDataOperationTime\": $opDataOperationTime[$i],\n      \"opDiagnosis\": $opDiagnosis[$i],\n      \"opMetricsOperationErrorRate\": $opMetricsOperationErrorRate[$i],\n      \"opStatus\": $opStatus[$i],\n\n      /* sa */\n      \"saAction\": $saAction[$i],\n      \"saDataRiskDetectionCount\": $saDataRiskDetectionCount[$i],\n      \"saDataSafetyActivationCount\": $saDataSafetyActivationCount[$i],\n      \"saDiagnosis\": $saDiagnosis[$i],\n      \"saStatus\": $saStatus[$i]\n    }\n  })\n)",
           "source": "url",
           "type": "json",
           "url": "/v2/entities/urn:ngsi-ld:AgrifarmRobotHouseSnapshot:site-01/value",
@@ -153,7 +150,7 @@
           }
         }
       ],
-      "title": "ステータス",
+      "title": "評価",
       "type": "stat"
     },
     {
@@ -161,6 +158,7 @@
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "FY2025対象外",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -178,6 +176,7 @@
             "lineWidth": 0,
             "spanNulls": false
           },
+          "displayName": "収穫精度",
           "mappings": [
             {
               "options": {
@@ -192,7 +191,7 @@
                   "text": "正常"
                 },
                 "unknown": {
-                  "color": "purple",
+                  "color": "#808080",
                   "index": 3,
                   "text": "不明"
                 },
@@ -214,52 +213,15 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "systemHealth"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "システム"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "robotHealth"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "ロボット"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "houseHealth"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "ハウス"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 4,
         "w": 19,
-        "x": 5,
+        "x": 3,
         "y": 1
       },
-      "id": 5,
+      "id": 12,
       "options": {
         "alignValue": "left",
         "legend": {
@@ -269,7 +231,7 @@
         },
         "mergeValues": true,
         "rowHeight": 0.9,
-        "showValue": "never",
+        "showValue": "auto",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
@@ -283,25 +245,12 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
-      "title": "ステータス遷移",
+      "title": "評価",
       "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "houseHealth",
-                "robotHealth",
-                "systemHealth",
-                "timestamp"
-              ]
-            }
-          }
-        },
         {
           "id": "convertFieldType",
           "options": {
@@ -309,136 +258,39 @@
               {
                 "destinationType": "time",
                 "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
               }
             ],
             "fields": {}
           }
         },
         {
-          "id": "organize",
+          "id": "filterFieldsByName",
           "options": {
-            "excludeByName": {},
-            "includeByName": {},
-            "indexByName": {
-              "houseHealth": 2,
-              "robotHealth": 1,
-              "systemHealth": 0,
-              "timestamp": 3
-            },
-            "renameByName": {}
+            "include": {
+              "names": [
+                "haStatus",
+                "timestamp"
+              ]
+            }
           }
         }
       ],
       "type": "state-timeline"
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 3,
-      "panels": [],
-      "title": "ロボット",
-      "type": "row"
-    },
-    {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "FY2025対象外",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "critical": {
-                  "color": "red",
-                  "index": 2,
-                  "text": "異常"
-                },
-                "healthy": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "正常"
-                },
-                "unknown": {
-                  "color": "purple",
-                  "index": 3,
-                  "text": "不明"
-                },
-                "warninig": {
-                  "color": "yellow",
-                  "index": 1,
-                  "text": "注意"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 5,
-        "x": 0,
-        "y": 11
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^robotHealth$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 1,
-          "refId": "A"
-        }
-      ],
-      "title": "ステータス",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
@@ -454,11 +306,11 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 19,
-        "x": 5,
-        "y": 11
+        "w": 11,
+        "x": 0,
+        "y": 5
       },
-      "id": 8,
+      "id": 14,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
@@ -469,7 +321,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^robotDiagnosis$/",
+          "fields": "/^haDiagnosis$/",
           "values": false
         },
         "showPercentChange": false,
@@ -483,7 +335,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -495,10 +347,11 @@
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "FY2025対象外",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
@@ -514,14 +367,14 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 19,
-        "x": 5,
-        "y": 13
+        "w": 11,
+        "x": 11,
+        "y": 5
       },
-      "id": 9,
+      "id": 15,
       "options": {
         "colorMode": "none",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "percentChangeColorMode": "standard",
@@ -529,7 +382,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^robotAction$/",
+          "fields": "/^haAction$/",
           "values": false
         },
         "showPercentChange": false,
@@ -543,7 +396,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -551,79 +404,44 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Dashboard --"
-      },
+      "description": "",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "velocityms"
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 5,
+        "h": 1,
+        "w": 22,
         "x": 0,
-        "y": 15
+        "y": 7
       },
-      "id": 12,
+      "id": 55,
       "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^robotSpeed$/",
-          "values": false
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
+        "content": "",
+        "mode": "markdown"
       },
       "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Dashboard --"
-          },
-          "panelId": 1,
-          "refId": "A"
-        }
-      ],
-      "title": "速度",
-      "type": "gauge"
+      "title": "メトリクス",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "FY2025対象外",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed"
           },
           "mappings": [],
-          "max": 200,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -632,31 +450,33 @@
               }
             ]
           },
-          "unit": "rotrpm"
+          "unit": "個"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 5,
-        "y": 15
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 8
       },
-      "id": 13,
+      "id": 52,
       "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^robotTireRotation$/",
+          "fields": "/^haMetricsUncertainCount$/",
           "values": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -665,37 +485,30 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
-      "title": "タイヤ回転数",
-      "type": "gauge"
+      "title": "不確実判定数",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "FY2025対象外",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
-              },
-              {
-                "color": "yellow",
-                "value": 20
-              },
-              {
-                "color": "green",
-                "value": 40
+                "color": "green"
               }
             ]
           },
@@ -704,26 +517,28 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 9,
-        "y": 15
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 8
       },
-      "id": 14,
+      "id": 53,
       "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^robotCameraClarity$/",
+          "fields": "/^haMetricsAmbiguityRate$/",
           "values": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -732,65 +547,87 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
-      "title": "カメラ鮮明度",
-      "type": "gauge"
+      "title": "曖昧判定率",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 11
+      },
+      "id": 102,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "FY2025対象外",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              },
-              {
-                "color": "green",
-                "value": 0.2
+                "color": "green"
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "個"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 13,
-        "y": 15
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 12
       },
-      "id": 15,
+      "id": 54,
       "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^robotBatteryLevel$/",
+          "fields": "/^haDataHarvestCount$/",
           "values": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -799,12 +636,74 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
-      "title": "バッテリー残量",
-      "type": "gauge"
+      "title": "収穫数",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "個"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 12
+      },
+      "id": 103,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^haDataDetectionCount$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "検知数",
+      "type": "stat"
     },
     {
       "collapsed": false,
@@ -812,11 +711,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 15
       },
-      "id": 2,
+      "id": 9,
       "panels": [],
-      "title": "ハウス",
+      "title": "収穫速度",
       "type": "row"
     },
     {
@@ -843,7 +742,7 @@
                   "text": "正常"
                 },
                 "unknown": {
-                  "color": "purple",
+                  "color": "#808080",
                   "index": 3,
                   "text": "不明"
                 },
@@ -869,11 +768,11 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
+        "w": 3,
         "x": 0,
-        "y": 24
+        "y": 16
       },
-      "id": 7,
+      "id": 16,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -884,7 +783,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^houseHealth$/",
+          "fields": "/^hsStatus$/",
           "values": false
         },
         "showPercentChange": false,
@@ -898,11 +797,11 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
-      "title": "ステータス",
+      "title": "評価",
       "type": "stat"
     },
     {
@@ -910,10 +809,139 @@
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 16
+      },
+      "id": 19,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "hsStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
@@ -929,11 +957,11 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 19,
-        "x": 5,
-        "y": 24
+        "w": 11,
+        "x": 0,
+        "y": 20
       },
-      "id": 10,
+      "id": 18,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
@@ -944,7 +972,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^houseDiagnosis$/",
+          "fields": "/^hsDiagnosis$/",
           "values": false
         },
         "showPercentChange": false,
@@ -958,7 +986,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -970,10 +998,11 @@
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed"
           },
           "mappings": [],
           "thresholds": {
@@ -989,11 +1018,11 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 19,
-        "x": 5,
-        "y": 26
+        "w": 11,
+        "x": 11,
+        "y": 20
       },
-      "id": 11,
+      "id": 17,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
@@ -1004,7 +1033,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^houseAction$/",
+          "fields": "/^hsAction$/",
           "values": false
         },
         "showPercentChange": false,
@@ -1018,12 +1047,500 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
       "title": "推奨アクション",
       "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 22
+      },
+      "id": 105,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "メトリクス",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 23
+      },
+      "id": 56,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^hsMetricsStopRate$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "走行停止率",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 26
+      },
+      "id": 104,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "velocityms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 27
+      },
+      "id": 57,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^hsDataRobotSpeed$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "ロボット走行速度",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "秒"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 27
+      },
+      "id": 58,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^hsDataProcessingTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "1果実あたりの処理時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 27
+      },
+      "id": 59,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^hsDataOperatingTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "収穫稼働時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 27
+      },
+      "id": 60,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^hsDataTravelStopTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "走行停止時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "E-01": {
+                  "index": 9,
+                  "text": "バッテリー残量低下"
+                },
+                "H-01": {
+                  "index": 7,
+                  "text": "視界不良"
+                },
+                "H-02": {
+                  "index": 8,
+                  "text": "収穫物満タン"
+                },
+                "R-01": {
+                  "index": 4,
+                  "text": "足元スタック"
+                },
+                "R-02": {
+                  "index": 5,
+                  "text": "進路妨害"
+                },
+                "R-03": {
+                  "index": 6,
+                  "text": "脱輪・転倒"
+                },
+                "S-01": {
+                  "index": 0,
+                  "text": "待機中"
+                },
+                "S-02": {
+                  "index": 1,
+                  "text": "移動中"
+                },
+                "S-03": {
+                  "index": 2,
+                  "text": "収穫中"
+                },
+                "S-04": {
+                  "index": 3,
+                  "text": "帰還中"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 27
+      },
+      "id": 62,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^hsDataStatusCode$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "ロボットステータス",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 8,
+      "panels": [],
+      "title": "環境適応性",
+      "type": "row"
     },
     {
       "datasource": {
@@ -1035,9 +1552,573 @@
           "color": {
             "mode": "thresholds"
           },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 31
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^adStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 31
+      },
+      "id": 28,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "adStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
           "mappings": [],
-          "max": 40,
-          "min": -10,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 35
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^adDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 35
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^adAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 37
+      },
+      "id": 107,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "degree"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 38
+      },
+      "id": 63,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^adDataYaw$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "ヨー",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": -5
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "degree"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 38
+      },
+      "id": 64,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^adDataPitch$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "ピッチ",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": -5
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "degree"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 38
+      },
+      "id": 65,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^adDataRoll$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "ロール",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1067,12 +2148,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 5,
+        "h": 5,
+        "w": 3,
         "x": 0,
-        "y": 28
+        "y": 41
       },
-      "id": 16,
+      "id": 66,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -1083,7 +2164,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^houseTemperature$/",
+          "fields": "/^adDataTemperature$/",
           "values": false
         },
         "showPercentChange": false,
@@ -1097,7 +2178,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1112,7 +2193,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1172,18 +2253,17 @@
                 "value": 35
               }
             ]
-          },
-          "unit": "celsius"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 19,
-        "x": 5,
-        "y": 28
+        "x": 3,
+        "y": 41
       },
-      "id": 17,
+      "id": 67,
       "options": {
         "legend": {
           "calcs": [],
@@ -1204,7 +2284,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1215,7 +2295,7 @@
           "options": {
             "include": {
               "names": [
-                "houseTemperature",
+                "adDataTemperature",
                 "timestamp"
               ]
             }
@@ -1231,7 +2311,7 @@
               },
               {
                 "destinationType": "number",
-                "targetField": "houseTemperature"
+                "targetField": "adDataTemperature"
               }
             ],
             "fields": {}
@@ -1245,6 +2325,7 @@
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1280,12 +2361,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 5,
+        "h": 5,
+        "w": 3,
         "x": 0,
-        "y": 34
+        "y": 46
       },
-      "id": 18,
+      "id": 68,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -1296,7 +2377,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^houseRelativeHumidity$/",
+          "fields": "/^adDataHumidity$/",
           "values": false
         },
         "showPercentChange": false,
@@ -1310,7 +2391,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1325,7 +2406,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1391,12 +2472,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 19,
-        "x": 5,
-        "y": 34
+        "x": 3,
+        "y": 46
       },
-      "id": 19,
+      "id": 69,
       "options": {
         "legend": {
           "calcs": [],
@@ -1417,7 +2498,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1428,8 +2509,8 @@
           "options": {
             "include": {
               "names": [
-                "houseRelativeHumidity",
-                "timestamp"
+                "timestamp",
+                "adDataHumidity"
               ]
             }
           }
@@ -1444,7 +2525,7 @@
               },
               {
                 "destinationType": "number",
-                "targetField": "houseRelativeHumidity"
+                "targetField": "adDataHumidity"
               }
             ],
             "fields": {}
@@ -1458,6 +2539,7 @@
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1493,12 +2575,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 5,
+        "h": 5,
+        "w": 3,
         "x": 0,
-        "y": 40
+        "y": 51
       },
-      "id": 20,
+      "id": 70,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -1509,7 +2591,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^houseIlluminance$/",
+          "fields": "/^adDataIlluminance$/",
           "values": false
         },
         "showPercentChange": false,
@@ -1523,7 +2605,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1538,7 +2620,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1604,12 +2686,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 19,
-        "x": 5,
-        "y": 40
+        "x": 3,
+        "y": 51
       },
-      "id": 21,
+      "id": 71,
       "options": {
         "legend": {
           "calcs": [],
@@ -1630,7 +2712,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1641,8 +2723,8 @@
           "options": {
             "include": {
               "names": [
-                "houseIlluminance",
-                "timestamp"
+                "timestamp",
+                "adDataIlluminance"
               ]
             }
           }
@@ -1657,7 +2739,7 @@
               },
               {
                 "destinationType": "number",
-                "targetField": "houseIlluminance"
+                "targetField": "adDataHumidity"
               }
             ],
             "fields": {}
@@ -1671,6 +2753,7 @@
         "type": "datasource",
         "uid": "-- Dashboard --"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1706,12 +2789,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 5,
+        "h": 5,
+        "w": 3,
         "x": 0,
-        "y": 46
+        "y": 56
       },
-      "id": 22,
+      "id": 72,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -1722,7 +2805,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^houseCo2$/",
+          "fields": "/^adDataCo2$/",
           "values": false
         },
         "showPercentChange": false,
@@ -1736,7 +2819,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1751,7 +2834,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1786,7 +2869,7 @@
               "mode": "off"
             }
           },
-          "displayName": "CO₂濃度",
+          "displayName": "照度",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1817,12 +2900,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 19,
-        "x": 5,
-        "y": 46
+        "x": 3,
+        "y": 56
       },
-      "id": 23,
+      "id": 73,
       "options": {
         "legend": {
           "calcs": [],
@@ -1843,7 +2926,7 @@
             "type": "datasource",
             "uid": "-- Dashboard --"
           },
-          "panelId": 1,
+          "panelId": 11,
           "refId": "A"
         }
       ],
@@ -1854,8 +2937,8 @@
           "options": {
             "include": {
               "names": [
-                "houseCo2",
-                "timestamp"
+                "timestamp",
+                "adDataCo2"
               ]
             }
           }
@@ -1870,7 +2953,7 @@
               },
               {
                 "destinationType": "number",
-                "targetField": "houseCo2"
+                "targetField": "adDataCo2"
               }
             ],
             "fields": {}
@@ -1878,6 +2961,4505 @@
         }
       ],
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 7,
+      "panels": [],
+      "title": "操作性",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 62
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 62
+      },
+      "id": 29,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "opStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 66
+      },
+      "id": 38,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 66
+      },
+      "id": 39,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 68
+      },
+      "id": 106,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "メトリクス",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 69
+      },
+      "id": 74,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opMetricsOperationErrorRate$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "操作エラー率",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 72
+      },
+      "id": 108,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 73
+      },
+      "id": 75,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opDataOperationTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "操作時間（平均）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "回"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 73
+      },
+      "id": 76,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opDataOperationSteps$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "操作ステップ数（平均）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "回"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 73
+      },
+      "id": 77,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^opDataOperationErrors$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "操作エラー数（平均）",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 6,
+      "panels": [],
+      "title": "メンテナンス性",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 77
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 77
+      },
+      "id": 30,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "mnStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 81
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 81
+      },
+      "id": 41,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 83
+      },
+      "id": 109,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "メトリクス",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "時間"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 84
+      },
+      "id": 78,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnMetricsMttr$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "MTTR",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 87
+      },
+      "id": 110,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "回"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 88
+      },
+      "id": 84,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataFailureCount$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "故障回数",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 88
+      },
+      "id": 83,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataTotalStopTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "停止時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 88
+      },
+      "id": 79,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsArm$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（アーム）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 88
+      },
+      "id": 80,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsHand$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（ハンド）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 88
+      },
+      "id": 81,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsCamera$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（カメラ）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 15,
+        "y": 88
+      },
+      "id": 82,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsWheels$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（車輪）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 18,
+        "y": 88
+      },
+      "id": 85,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsTray$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（トレイ）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 91
+      },
+      "id": 86,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsCommunication$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（通信）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 91
+      },
+      "id": 87,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsControlUnit$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（制御ユニット）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 91
+      },
+      "id": 88,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^mnDataPartFailureProbsPower$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "予兆発生率（電源）",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 94
+      },
+      "id": 5,
+      "panels": [],
+      "title": "コスト効率",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 95
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^ceStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 95
+      },
+      "id": 31,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "ceStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 99
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^ceDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 99
+      },
+      "id": 43,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^ceAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 101
+      },
+      "id": 111,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "個"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 102
+      },
+      "id": 91,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^ceDataHarvestCount$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "収穫数",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 102
+      },
+      "id": 89,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^ceDataOperatingTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "稼働時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 102
+      },
+      "id": 90,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^ceDataTotalStopTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "停止時間",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 105
+      },
+      "id": 4,
+      "panels": [],
+      "title": "安全性",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 106
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^saStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 106
+      },
+      "id": 32,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "saStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 110
+      },
+      "id": 44,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^saDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 110
+      },
+      "id": 45,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^saAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 112
+      },
+      "id": 112,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "回"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 113
+      },
+      "id": 92,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^saDataRiskDetectionCount$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "安全性リスク検知回数",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "回"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 113
+      },
+      "id": 93,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^saDataSafetyActivationCount$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "安全装置作動回数",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 116
+      },
+      "id": 3,
+      "panels": [],
+      "title": "データ活用",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 117
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^duStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 117
+      },
+      "id": 33,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "duStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 121
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^duDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 121
+      },
+      "id": 47,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^duAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 123
+      },
+      "id": 2,
+      "panels": [],
+      "title": "耐久性",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 124
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 124
+      },
+      "id": 34,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "dbStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 128
+      },
+      "id": 48,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 128
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 130
+      },
+      "id": 113,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "メトリクス",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 9.5
+              }
+            ]
+          },
+          "unit": "時間"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 131
+      },
+      "id": 94,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbMetricsMtbf$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "MTBF",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 131
+      },
+      "id": 95,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbMetricsOperationRate$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "稼働率",
+      "type": "stat"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 22,
+        "x": 0,
+        "y": 134
+      },
+      "id": 114,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.2",
+      "title": "データ",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 135
+      },
+      "id": 96,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbDataOperatingTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "稼働時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "分"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 135
+      },
+      "id": 97,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbDataTotalStopTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "停止時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "回"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 135
+      },
+      "id": 98,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbDataFailureCount$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "故障回数",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "秒"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 135
+      },
+      "id": 99,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbDataProcessingTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "1果実あたりの処理時間",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "velocityms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 135
+      },
+      "id": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbDataRobotSpeed$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "ロボット走行速度",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "E-01": {
+                  "index": 9,
+                  "text": "バッテリー残量低下"
+                },
+                "H-01": {
+                  "index": 7,
+                  "text": "視界不良"
+                },
+                "H-02": {
+                  "index": 8,
+                  "text": "収穫物満タン"
+                },
+                "R-01": {
+                  "index": 4,
+                  "text": "足元スタック"
+                },
+                "R-02": {
+                  "index": 5,
+                  "text": "進路妨害"
+                },
+                "R-03": {
+                  "index": 6,
+                  "text": "脱輪・転倒"
+                },
+                "S-01": {
+                  "index": 0,
+                  "text": "待機中"
+                },
+                "S-02": {
+                  "index": 1,
+                  "text": "移動中"
+                },
+                "S-03": {
+                  "index": 2,
+                  "text": "収穫中"
+                },
+                "S-04": {
+                  "index": 3,
+                  "text": "帰還中"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 15,
+        "y": 135
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^dbDataStatusCode$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "ロボットステータス",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 138
+      },
+      "id": 1,
+      "panels": [],
+      "title": "倫理性",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 139
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^etStatus$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "displayName": "収穫精度",
+          "mappings": [
+            {
+              "options": {
+                "critical": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "異常"
+                },
+                "healthy": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "正常"
+                },
+                "unknown": {
+                  "color": "#808080",
+                  "index": 3,
+                  "text": "不明"
+                },
+                "warning": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "注意"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 19,
+        "x": 3,
+        "y": 139
+      },
+      "id": 35,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "評価",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              },
+              {
+                "destinationType": "string",
+                "targetField": "haStatus"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "etStatus",
+                "timestamp"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 0,
+        "y": 143
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^etDiagnosis$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "診断",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "description": "FY2025対象外",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 11,
+        "x": 11,
+        "y": 143
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^etAction$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 11,
+          "refId": "A"
+        }
+      ],
+      "title": "推奨アクション",
+      "type": "stat"
     }
   ],
   "preload": false,
@@ -1894,6 +7476,6 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "第三者評価",
-  "uid": "e05353b2-2953-45a2-a6f5-a9e99fbbeb21",
-  "version": 3
+  "uid": "510b40ad-9b16-4918-907f-63bfd9ac162c",
+  "version": 10
 }

--- a/init.d/strawberry-robofarm.sh
+++ b/init.d/strawberry-robofarm.sh
@@ -47,7 +47,7 @@ if [ "$STATUS" -eq 404 ]; then
       \"entities\": [{\"type\": \"AgrifarmRobotHouseSnapshot\"}],
       \"watchedAttributes\": [\"systemTimestamp\"],
       \"notification\": {
-        \"attributes\": [\"systemTimestamp\", \"robot\", \"house\", \"analysis\"],
+        \"attributes\": [\"systemTimestamp\", \"analysis\"],
         \"endpoint\": {
           \"uri\": \"${NOTIFY_URI}\",
           \"accept\": \"application/json\",


### PR DESCRIPTION
## 概要

第三者評価ダッシュボード作成

## 対応内容

新しいデータモデルに従い、ダッシュボードを新規に作成した。

## 影響範囲

第三者評価のダッシュボードの表示

## 動作確認

ローカルで投入したデータがダッシュボードに反映されることを確認

## 制約事項

## レビュー観点

- 必要な情報が漏れなく表示されているかどうか
- 入力したデータが正しく表示されるか

## レビュー期間

2026/02/18(Wed) - 2026/02/20(Fri)

## 補足

[本番環境](https://platform.ak-agri.systemdesign-apu.com/grafana) にアップロード済みです。