### PR TITLE
キイチゴ受発注システムのダッシュボード

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
     healthcheck:
       test: curl --fail -s http://nginx/api/orion/version || exit 1
       interval: 5s
+      start_period: 30s 
 
   grafana:
     labels:
@@ -130,6 +131,7 @@ services:
       - ./grafana/dashboard.yml:/etc/grafana/provisioning/dashboards/dashboard.yml
       - ./grafana/dashboard-gis.yml:/etc/grafana/provisioning/dashboards/dashboard-gis.yml
       - ./grafana/dashboard-3rd.yml:/etc/grafana/provisioning/dashboards/dashboard-3rd.yml
+      - ./grafana/dashboard-raspberry.yml:/etc/grafana/provisioning/dashboards/dashboard-raspberry.yml
       - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
     entrypoint:
       - /bin/bash

--- a/grafana/dashboard-raspberry.yml
+++ b/grafana/dashboard-raspberry.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'Fresh Order System'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/Raspberry.json
+      foldersFromFilesStructure: false

--- a/grafana/dashboards/Raspberry.json
+++ b/grafana/dashboards/Raspberry.json
@@ -1,0 +1,702 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "panels": [],
+      "title": "生産計画",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "P0DB2B379060E8607"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pricePerKg FROZEN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "冷凍"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pricePerKg FRESH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "生鮮"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "displayLabels": [
+          "value"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": []
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "count"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "columns": [],
+          "computed_columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "P0DB2B379060E8607"
+          },
+          "filterExpression": "",
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "(\n    /* タイムスタンプ */\n    $ts := $.attributes[attrName = \"systemTimestamp\"].values;\n    \n    /* 属性 */\n    $createdAt := $.attributes[attrName = \"data\"].values.createdAt;\n    $id := $.attributes[attrName = \"data\"].values.id;\n    $isPublished := $.attributes[attrName = \"data\"].values.isPublished;\n    $packageType := $.attributes[attrName = \"data\"].values.packageType;\n    $planNumber := $.attributes[attrName = \"data\"].values.planNumber;\n    $pricePerKg := $.attributes[attrName = \"data\"].values.pricePerKg;\n    $producerId := $.attributes[attrName = \"data\"].values.producerId;\n    $quantity := $.attributes[attrName = \"data\"].values.quantity;\n    $shippingMonth := $.attributes[attrName = \"data\"].values.shippingMonth;\n    $shippingWeek := $.attributes[attrName = \"data\"].values.shippingWeek;\n    $updatedAt := $.attributes[attrName = \"data\"].values.updatedAt;\n    $variety := $.attributes[attrName = \"data\"].values.variety;\n\n    /* 出力 */\n    $map($ts, function($v, $i) {\n        {\n            \"timestamp\": $v,\n            \"createdAt\": $createdAt[$i],\n            \"id\": $id[$i],\n            \"isPublished\": $isPublished[$i],\n            \"packageType\": $packageType[$i],\n            \"planNumber\": $planNumber[$i],\n            \"pricePerKg\": $pricePerKg[$i],\n            \"producerId\": $producerId[$i],\n            \"quantity\": $quantity[$i],\n            \"shippingMonth\": $shippingMonth[$i],\n            \"shippingWeek\": $shippingWeek[$i],\n            \"updatedAt\": $updatedAt[$i],\n            \"variety\": $variety[$i]\n        }\n    })\n)",
+          "source": "url",
+          "summarizeExpression": "",
+          "type": "json",
+          "url": "/v2/entities/urn:ngsi-ld:FreshOrderSystemProductionPlan:001/value",
+          "url_options": {
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Fiware-Service",
+                "value": "fresh_order_system"
+              },
+              {
+                "key": "Fiware-ServicePath",
+                "value": "/"
+              }
+            ],
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "荷姿の割合",
+      "transformations": [
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "packageType"
+            ],
+            "keepFields": true,
+            "naming": {
+              "asLabels": true
+            }
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "pricePerKg FROZEN",
+                "pricePerKg FRESH"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "panels": [],
+      "title": "出荷予定",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "P0DB2B379060E8607"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "columns": [],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "(\n    /* タイムスタンプ */\n    $ts := $.attributes[attrName = \"systemTimestamp\"].values;\n    \n    /* 属性 */\n    $createdAt := $.attributes[attrName = \"data\"].values.createdAt;\n    $id := $.attributes[attrName = \"data\"].values.id;\n    $isPublished := $.attributes[attrName = \"data\"].values.isPublished;\n    $packageType := $.attributes[attrName = \"data\"].values.packageType;\n    $pricePerKg := $.attributes[attrName = \"data\"].values.pricePerKg;\n    $producerId := $.attributes[attrName = \"data\"].values.producerId;\n    $quantity := $.attributes[attrName = \"data\"].values.quantity;\n    $scheduleNumber := $.attributes[attrName = \"data\"].values.scheduleNumber;\n    $shippingMonth := $.attributes[attrName = \"data\"].values.shippingMonth;\n    $shippingWeek := $.attributes[attrName = \"data\"].values.shippingWeek;\n    $updatedAt := $.attributes[attrName = \"data\"].values.updatedAt;\n    $variety := $.attributes[attrName = \"data\"].values.variety;\n\n    /* 出力 */\n    $map($ts, function($v, $i) {\n        {\n            \"timestamp\": $v,\n            \"createdAt\": $createdAt[$i],\n            \"id\": $id[$i],\n            \"isPublished\": $isPublished[$i],\n            \"packageType\": $packageType[$i],\n            \"pricePerKg\": $pricePerKg[$i],\n            \"producerId\": $producerId[$i],\n            \"quantity\": $quantity[$i],\n            \"scheduleNumber\": $scheduleNumber[$i],\n            \"shippingMonth\": $shippingMonth[$i],\n            \"shippingWeek\": $shippingWeek[$i],\n            \"updatedAt\": $updatedAt[$i],\n            \"variety\": $variety[$i]\n        }\n    })\n)",
+          "source": "url",
+          "type": "json",
+          "url": "/v2/entities/urn:ngsi-ld:FreshOrderSystemShippingSchedule:001/value",
+          "url_options": {
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Fiware-Service",
+                "value": "fresh_order_system"
+              },
+              {
+                "key": "Fiware-ServicePath",
+                "value": "/"
+              }
+            ],
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "出荷予定登録",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "quantity",
+                "variety",
+                "timestamp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "variety"
+            ],
+            "keepFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 3,
+      "panels": [],
+      "title": "在庫",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "P0DB2B379060E8607"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "columns": [],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "(\n    /* タイムスタンプ */\n    $ts := $.attributes[attrName = \"systemTimestamp\"].values;\n    \n    /* 属性 */\n    $createdAt := $.attributes[attrName = \"data\"].values.createdAt;\n    $id := $.attributes[attrName = \"data\"].values.id;\n    $isPublished := $.attributes[attrName = \"data\"].values.isPublished;\n    $packageType := $.attributes[attrName = \"data\"].values.packageType;\n    $pricePerKg := $.attributes[attrName = \"data\"].values.pricePerKg;\n    $producerId := $.attributes[attrName = \"data\"].values.producerId;\n    $quantity := $.attributes[attrName = \"data\"].values.quantity;\n    $updatedAt := $.attributes[attrName = \"data\"].values.updatedAt;\n    $variety := $.attributes[attrName = \"data\"].values.variety;\n\n    /* 出力 */\n    $map($ts, function($v, $i) {\n        {\n            \"timestamp\": $v,\n            \"createdAt\": $createdAt[$i],\n            \"id\": $id[$i],\n            \"isPublished\": $isPublished[$i],\n            \"packageType\": $packageType[$i],\n            \"pricePerKg\": $pricePerKg[$i],\n            \"producerId\": $producerId[$i],\n            \"quantity\": $quantity[$i],\n            \"updatedAt\": $updatedAt[$i],\n            \"variety\": $variety[$i]\n        }\n    })\n)",
+          "source": "url",
+          "type": "json",
+          "url": "/v2/entities/urn:ngsi-ld:FreshOrderSystemInventory:001/value",
+          "url_options": {
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Fiware-Service",
+                "value": "fresh_order_system"
+              },
+              {
+                "key": "Fiware-ServicePath",
+                "value": "/"
+              }
+            ],
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "在庫登録",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "packageType",
+                "quantity",
+                "timestamp",
+                "variety"
+              ]
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "variety"
+            ],
+            "keepFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 2,
+      "panels": [],
+      "title": "受注",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "P0DB2B379060E8607"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "columns": [],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "(\n    /* タイムスタンプ */\n    $ts := $.attributes[attrName = \"systemTimestamp\"].values;\n    \n    /* 属性 */\n    $__typename := $.attributes[attrName = \"data\"].values.__typename;\n    $createdAt := $.attributes[attrName = \"data\"].values.createdAt;\n    $customerId := $.attributes[attrName = \"data\"].values.customerId;\n    $desiredDeliveryDate := $.attributes[attrName = \"data\"].values.desiredDeliveryDate;\n    $id := $.attributes[attrName = \"data\"].values.id;\n    $orderNumber := $.attributes[attrName = \"data\"].values.orderNumber;\n    $packageType := $.attributes[attrName = \"data\"].values.packageType;\n    $pricePerKg := $.attributes[attrName = \"data\"].values.pricePerKg;\n    $producerId := $.attributes[attrName = \"data\"].values.producerId;\n    $quantity := $.attributes[attrName = \"data\"].values.quantity;\n    $status := $.attributes[attrName = \"data\"].values.status;\n    $totalAmount := $.attributes[attrName = \"data\"].values.totalAmount;\n    $updatedAt := $.attributes[attrName = \"data\"].values.updatedAt;\n    $variety := $.attributes[attrName = \"data\"].values.variety;\n\n    /* 出力 */\n    $map($ts, function($v, $i) {\n        {\n            \"timestamp\": $v,\n            \"__typename\": $__typename[$i],\n            \"createdAt\": $createdAt[$i],\n            \"customerId\": $customerId[$i],\n            \"desiredDeliveryDate\": $desiredDeliveryDate[$i],\n            \"id\": $id[$i],\n            \"orderNumber\": $orderNumber[$i],\n            \"packageType\": $packageType[$i],\n            \"pricePerKg\": $pricePerKg[$i],\n            \"producerId\": $producerId[$i],\n            \"quantity\": $quantity[$i],\n            \"status\": $status[$i],\n            \"totalAmount\": $totalAmount[$i],\n            \"updatedAt\": $updatedAt[$i],\n            \"variety\": $variety[$i]\n        }\n    })\n)",
+          "source": "url",
+          "type": "json",
+          "url": "/v2/entities/urn:ngsi-ld:FreshOrderSystemOrder:001/value",
+          "url_options": {
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Fiware-Service",
+                "value": "fresh_order_system"
+              },
+              {
+                "key": "Fiware-ServicePath",
+                "value": "/"
+              }
+            ],
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "受注登録",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "quantity",
+                "timestamp",
+                "variety"
+              ]
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "timestamp"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "variety"
+            ],
+            "keepFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1y",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "キイチゴ受発注システム",
+  "uid": "b9d82442-38af-4f18-8803-3e4fe6316954",
+  "version": 2
+}

--- a/grafana/dashboards/Raspberry.json
+++ b/grafana/dashboards/Raspberry.json
@@ -42,88 +42,160 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
-          "mappings": []
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "masskg"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "pricePerKg FROZEN"
+              "options": "YELLOW"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "冷凍"
-              },
-              {
                 "id": "color",
                 "value": {
-                  "fixedColor": "blue",
+                  "fixedColor": "yellow",
                   "mode": "fixed"
                 }
+              },
+              {
+                "id": "displayName",
+                "value": "イエロー"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "pricePerKg FRESH"
+              "options": "HERITAGE"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "生鮮"
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
               },
+              {
+                "id": "displayName",
+                "value": "ヘリテージ"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CHILCOTIN"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "チルコチン"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "shippingMonth\\variety"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "月"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HANOVER"
+            },
+            "properties": [
               {
                 "id": "color",
                 "value": {
                   "fixedColor": "green",
                   "mode": "fixed"
                 }
+              },
+              {
+                "id": "displayName",
+                "value": "ハノーバー"
               }
             ]
           }
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 4,
+        "h": 10,
+        "w": 24,
         "x": 0,
         "y": 1
       },
       "id": 1,
       "options": {
-        "displayLabels": [
-          "value"
-        ],
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
         "legend": {
+          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true,
-          "values": []
+          "showLegend": true
         },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "count"
-          ],
-          "fields": "/.*/",
-          "values": false
-        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
           "sort": "none"
-        }
+        },
+        "xField": "shippingMonth\\variety",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -165,33 +237,78 @@
           }
         }
       ],
-      "title": "荷姿の割合",
+      "title": "月別生産計画",
       "transformations": [
-        {
-          "id": "partitionByValues",
-          "options": {
-            "fields": [
-              "packageType"
-            ],
-            "keepFields": true,
-            "naming": {
-              "asLabels": true
-            }
-          }
-        },
         {
           "id": "filterFieldsByName",
           "options": {
             "include": {
               "names": [
-                "pricePerKg FROZEN",
-                "pricePerKg FRESH"
+                "quantity",
+                "shippingMonth",
+                "variety"
               ]
             }
           }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "quantity": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "shippingMonth": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "variety": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "variety",
+            "emptyValue": "zero",
+            "rowField": "shippingMonth",
+            "valueField": "quantity (sum)"
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "shippingMonth\\variety"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "CHILCOTIN": 1,
+              "HANOVER": 2,
+              "HERITAGE": 3,
+              "YELLOW": 4,
+              "shippingMonth\\variety": 0
+            },
+            "renameByName": {}
+          }
         }
       ],
-      "type": "piechart"
+      "type": "barchart"
     },
     {
       "collapsed": false,
@@ -199,7 +316,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 11
       },
       "id": 4,
       "panels": [],
@@ -214,7 +331,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
             "axisBorderShow": false,
@@ -222,28 +339,16 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 80,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
             "lineWidth": 1,
-            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -255,35 +360,131 @@
             "steps": [
               {
                 "color": "green"
+              }
+            ]
+          },
+          "unit": "masskg"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CHILCOTIN"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
               },
               {
-                "color": "red",
-                "value": 80
+                "id": "displayName",
+                "value": "チルコチン"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "YELLOW"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "イエロー"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HERITAGE"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "ヘリテージ"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "shippingMonth\\variety"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "月"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HANOVER"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "ハノーバー"
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 12
       },
       "id": 6,
       "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
           "sort": "none"
-        }
+        },
+        "xField": "shippingMonth\\variety",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -318,7 +519,7 @@
           }
         }
       ],
-      "title": "出荷予定登録",
+      "title": "月別出荷予定",
       "transformations": [
         {
           "id": "filterFieldsByName",
@@ -327,34 +528,69 @@
               "names": [
                 "quantity",
                 "variety",
-                "timestamp"
+                "shippingMonth"
               ]
             }
           }
         },
         {
-          "id": "convertFieldType",
+          "id": "groupBy",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "time",
-                "targetField": "timestamp"
+            "fields": {
+              "quantity": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "shippingMonth": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "variety": {
+                "aggregations": [],
+                "operation": "groupby"
               }
-            ],
-            "fields": {}
+            }
           }
         },
         {
-          "id": "partitionByValues",
+          "id": "groupingToMatrix",
           "options": {
-            "fields": [
-              "variety"
-            ],
-            "keepFields": false
+            "columnField": "variety",
+            "emptyValue": "zero",
+            "rowField": "shippingMonth",
+            "valueField": "quantity (sum)"
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "shippingMonth\\variety"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "CHILCOTIN": 1,
+              "HANOVER": 2,
+              "HERITAGE": 3,
+              "YELLOW": 4,
+              "shippingMonth\\variety": 0
+            },
+            "renameByName": {}
           }
         }
       ],
-      "type": "timeseries"
+      "type": "barchart"
     },
     {
       "collapsed": false,
@@ -362,7 +598,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 20
       },
       "id": 3,
       "panels": [],
@@ -377,7 +613,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "green",
+            "mode": "fixed"
           },
           "custom": {
             "axisBorderShow": false,
@@ -385,28 +622,16 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 80,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
             "lineWidth": 1,
-            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -418,35 +643,107 @@
             "steps": [
               {
                 "color": "green"
+              }
+            ]
+          },
+          "unit": "masskg"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FROZEN"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
               },
               {
-                "color": "red",
-                "value": 80
+                "id": "displayName",
+                "value": "冷凍"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FRESH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "生鮮"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "variety\\packageType"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "CHILCOTIN": {
+                        "index": 1,
+                        "text": "チルコチン"
+                      },
+                      "HANOVER": {
+                        "index": 0,
+                        "text": "ハノーバー"
+                      },
+                      "HERITAGE": {
+                        "index": 2,
+                        "text": "ヘリテージ"
+                      },
+                      "YELLOW": {
+                        "index": 3,
+                        "text": "イエロー"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 21
       },
       "id": 7,
       "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
           "sort": "none"
-        }
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
       },
       "pluginVersion": "12.0.2",
       "targets": [
@@ -481,44 +778,64 @@
           }
         }
       ],
-      "title": "在庫登録",
+      "title": "年間在庫登録量",
       "transformations": [
         {
           "id": "filterFieldsByName",
           "options": {
             "include": {
               "names": [
-                "packageType",
                 "quantity",
-                "timestamp",
-                "variety"
+                "variety",
+                "packageType"
               ]
             }
           }
         },
         {
-          "id": "convertFieldType",
+          "id": "groupBy",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "time",
-                "targetField": "timestamp"
+            "fields": {
+              "packageType": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "quantity": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "variety": {
+                "aggregations": [],
+                "operation": "groupby"
               }
-            ],
-            "fields": {}
+            }
           }
         },
         {
-          "id": "partitionByValues",
+          "id": "groupingToMatrix",
           "options": {
-            "fields": [
-              "variety"
-            ],
-            "keepFields": false
+            "columnField": "packageType",
+            "emptyValue": "zero",
+            "rowField": "variety",
+            "valueField": "quantity (sum)"
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "variety\\packageType"
+              }
+            ]
           }
         }
       ],
-      "type": "timeseries"
+      "type": "barchart"
     },
     {
       "collapsed": false,
@@ -526,7 +843,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 29
       },
       "id": 2,
       "panels": [],
@@ -550,9 +867,9 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
+            "barWidthFactor": 0.5,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -582,21 +899,76 @@
             "steps": [
               {
                 "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "count (count)"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "回"
+              },
+              {
+                "id": "displayName",
+                "value": "受注数"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "totalAmount (sum)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "円"
+              },
+              {
+                "id": "displayName",
+                "value": "受注額"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 30
       },
       "id": 8,
       "options": {
@@ -645,16 +1017,15 @@
           }
         }
       ],
-      "title": "受注登録",
+      "title": "月別受注数、受注額",
       "transformations": [
         {
           "id": "filterFieldsByName",
           "options": {
             "include": {
               "names": [
-                "quantity",
-                "timestamp",
-                "variety"
+                "totalAmount",
+                "createdAt"
               ]
             }
           }
@@ -665,23 +1036,311 @@
             "conversions": [
               {
                 "destinationType": "time",
-                "targetField": "timestamp"
+                "targetField": "createdAt"
               }
             ],
             "fields": {}
           }
         },
         {
-          "id": "partitionByValues",
+          "id": "formatTime",
           "options": {
-            "fields": [
-              "variety"
+            "outputFormat": "YYYY-M",
+            "timeField": "createdAt",
+            "useTimezone": true
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "count",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "createdAt"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [],
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "count": {
+                "aggregations": [
+                  "count"
+                ],
+                "operation": "aggregate"
+              },
+              "createdAt": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "totalAmount": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "createdAt"
+              }
             ],
-            "keepFields": false
+            "fields": {}
           }
         }
       ],
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "width": 128
+          },
+          "mappings": [
+            {
+              "options": {
+                "CHILCOTIN": {
+                  "index": 2,
+                  "text": "チルコチン"
+                },
+                "FRESH": {
+                  "index": 5,
+                  "text": "生鮮"
+                },
+                "FROZEN": {
+                  "index": 4,
+                  "text": "冷凍"
+                },
+                "HANOVER": {
+                  "index": 1,
+                  "text": "ハノーバー"
+                },
+                "HERITAGE": {
+                  "index": 3,
+                  "text": "ヘリテージ"
+                },
+                "YELLOW": {
+                  "index": 0,
+                  "text": "イエロー"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "順位"
+            },
+            "properties": []
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "品種"
+            },
+            "properties": []
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "荷姿"
+            },
+            "properties": []
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "受注額"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "円"
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 9,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 8,
+          "refId": "A"
+        }
+      ],
+      "title": "年間受注額ランキング",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "packageType",
+                "totalAmount",
+                "variety"
+              ]
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "packageType": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "totalAmount": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "variety": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "totalAmount (sum)"
+              }
+            ]
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "index",
+            "mode": "index",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "rank",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "index"
+                }
+              },
+              "right": {
+                "fixed": "1"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "index": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "packageType": 2,
+              "rank": 0,
+              "totalAmount (sum)": 3,
+              "variety": 1
+            },
+            "renameByName": {
+              "packageType": "荷姿",
+              "rank": "順位",
+              "totalAmount (sum)": "受注額",
+              "variety": "品種"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "preload": false,
@@ -691,8 +1350,8 @@
     "list": []
   },
   "time": {
-    "from": "now-1y",
-    "to": "now"
+    "from": "2024-12-31T15:00:00.000Z",
+    "to": "2026-03-08T15:00:00.000Z"
   },
   "timepicker": {},
   "timezone": "browser",


### PR DESCRIPTION
## 概要

キイチゴ受発注システムのダッシュボード

## 対応内容

- キイチゴ受発注システムの情報を表示するダッシュボードを新規に追加

## 影響範囲

- キイチゴ受発注システムの情報を表示するダッシュボード

## 動作確認

ローカル環境でキイチゴ受発注システムの情報を表示するダッシュボードが表示されること。

## 制約事項

特になし

## レビュー観点

それっぽく表示されているかどうか。

## レビュー期間

2026/03/10 (Tue) - 2026/03/11 (Wed)

## 補足